### PR TITLE
Enable NV12/P010 NVENC zero-copy pipeline

### DIFF
--- a/Plugins/PanoramaCapture/Docs/NV12_P010_ZeroCopyPlan.md
+++ b/Plugins/PanoramaCapture/Docs/NV12_P010_ZeroCopyPlan.md
@@ -1,0 +1,95 @@
+# Plan to Enable NV12 / P010 NVENC Zero-Copy
+
+This document outlines the engineering tasks required to extend the existing BGRA8 zero-copy pipeline so that NV12 and P010 color formats can also submit GPU textures directly to NVENC. Each section calls out dependencies, implementation details, and validation steps.
+
+## 1. Render Graph Output Enhancements
+
+### 1.1 Shared render graph data
+- Introduce a per-frame render graph payload (e.g., `FPanoramaEncodeResources`) that carries:
+  - Existing linear equirect render target for PNG/preview paths.
+  - New Y and UV plane UAVs for NV12.
+  - New 10-bit Y and UV plane UAVs for P010.
+  - Resource transitions/fences required before handing the textures to NVENC.
+- Extend `FPanoramaFrame` to store `FTextureRHIRef` handles for each plane alongside the legacy CPU buffers.
+
+### 1.2 NV12 render pass
+- Author a compute shader variant that writes:
+  - Luma plane as `R8_UNORM` texture sized `(Width, Height)`.
+  - Interleaved chroma plane as `RG8_UNORM` with half resolution.
+- Ensure thread group size keeps NVENC pitch alignment (multiple of 128 bytes for luma, 64 for chroma).
+- Add render graph passes that create UAV-backed textures with `TexCreate_UAV | TexCreate_RenderTargetable | TexCreate_Shared` flags and skip mip generation.
+
+### 1.3 P010 render pass
+- Emit luma as `R16_UINT` and chroma as `RG16_UINT` with values left-shifted by 6 bits (NVENC expects 10-bit samples in the high bits).
+- Validate that UE RHI exposes these DXGI formats (`DXGI_FORMAT_R16_UNORM` / `DXGI_FORMAT_R16G16_UNORM` on D3D11 and `DXGI_FORMAT_P010` equivalents on D3D12 via create parameters).
+- For D3D11, use texture arrays or shared handles because typeless 10-bit formats require explicit resource creation through `FD3D11DynamicRHI::RHICreateTexture2D`.
+
+### 1.4 Synchronization and lifetime
+- Transition the planar textures to `ERHIAccess::CopySrc` after compute passes finish.
+- Defer releasing the render graph resources until the encoding thread signals completion (introduce a fence or reuse the existing frame recycling mechanism).
+
+## 2. NVENC Session Negotiation
+
+### 2.1 Capability probing
+- During encoder initialization, call `NvEncGetEncodeCaps` with:
+  - `NV_ENC_CAPS_SUPPORT_DIRECTX_TEXTURE` to confirm DirectX intake.
+  - `NV_ENC_CAPS_SUPPORT_YUV444_ENCODE` / `NV_ENC_CAPS_SUPPORT_10BIT_ENCODE` for P010.
+- Cache capability results in the capture status so the UI can surface whether GPU planes will be consumed or the CPU fallback will be used.
+
+### 2.2 Session configuration
+- When color format is NV12:
+  - Set `NV_ENC_BUFFER_FORMAT_NV12` for input.
+  - Enable `enableOutputInVidmem` and `enableInputInVidmem` in `NV_ENC_INITIALIZE_PARAMS` to stay on GPU memory.
+- When color format is P010:
+  - Use `NV_ENC_BUFFER_FORMAT_YUV420_10BIT`.
+  - Pick HEVC-only presets (fall back to CPU or disallow combination if user forces H.264).
+- Maintain BGRA path unchanged, but refactor encoder code so the input registration logic is shared between formats.
+
+### 2.3 Texture registration
+- For each frame:
+  - Register luma and chroma textures separately via `NvEncRegisterResource` with `resourceType = NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX` and appropriate `subResourceIndex`.
+  - Map each resource using `NvEncMapInputResource` and populate `NV_ENC_PIC_PARAMS` with plane pointers (`inputBuffer`, `inputBufferYuv[2]`).
+  - Unmap after submission to avoid leaking registered handles.
+- Consider persistent registration (register once, reuse) keyed by render target pointers to reduce per-frame overhead.
+
+## 3. Capture Manager Integration
+
+### 3.1 Frame queue updates
+- Extend the frame queue items to reference planar GPU textures.
+- Introduce ref-counted wrappers (e.g., `FPanoramaGpuPlaneHandle`) so that when the worker thread finishes encoding, it releases the RHI resources or enqueues them back to the renderer for reuse.
+
+### 3.2 PNG / preview coexistence
+- Continue producing linear RGBA render target for PNG readback and preview materials.
+- Guard the planar pass execution so it runs only when NVENC is active; PNG-only sessions can skip the extra compute work.
+- Ensure that CPU readbacks don't stall the GPU when zero-copy is active by sequencing passes appropriately (NVENC first, PNG readback after fence completion if both outputs are requested).
+
+## 4. Editor & Diagnostics
+
+### 4.1 Status reporting
+- Extend the capture status payload with fields:
+  - `bGpuPlaneBuilt` (per format).
+  - `bGpuPlaneSubmitted` (per frame) with failure reasons.
+  - Capability flags exposed by NVENC probing.
+- Update the Slate panel to show when NV12/P010 zero-copy is active, and highlight fallback reasons (e.g., "GPU format unsupported", "D3D11 typeless creation failed").
+
+### 4.2 Configuration guards
+- If the user selects P010 without HEVC, display an inline warning and automatically disable zero-copy (still allow CPU path).
+- Provide tooltips explaining alignment requirements and potential performance implications.
+
+## 5. Validation Plan
+
+1. **Unit tests / automation**: Implement small `AutomationSpec` cases that exercise encoder initialization for NV12 and P010 with mocked capability responses.
+2. **PIE testing**: Record short mono/stereo sessions in UE5.4, 5.5, and 5.6 builds using RTX 30- and 40-series GPUs. Verify zero-copy activation in logs/UI.
+3. **Bitstream inspection**: Use `ffprobe` to confirm pixel formats (`yuv420p`, `p010le`) and metadata in resulting MP4/MKV files.
+4. **Stress tests**: Run 8K stereo capture for at least five minutes, monitoring ring buffer utilization and ensuring no CPU conversions occur.
+
+## 6. Dependencies & Risks
+
+- **Driver requirements**: Document minimum NVIDIA driver versions that expose DirectX intake for NV12/P010 (typically R465+).
+- **RHI differences**: UE5.4 ships with legacy D3D12 RHI macros; guard code with `UE_VERSION_OLDER_THAN` where necessary.
+- **Resource lifetime**: Improper synchronization may lead to GPU hangs. Test with the D3D debug layer enabled.
+- **Fallback parity**: Keep CPU conversion path functional for legacy GPUs or when capability checks fail.
+
+---
+
+By following this plan, the plugin will extend its zero-copy capabilities beyond BGRA8, allowing NV12 and P010 formats to bypass CPU memory entirely while preserving existing PNG workflows and diagnostic tooling.

--- a/Plugins/PanoramaCapture/PanoramaCapture.uplugin
+++ b/Plugins/PanoramaCapture/PanoramaCapture.uplugin
@@ -1,0 +1,44 @@
+{
+    "FileVersion": 3,
+    "Version": 1,
+    "VersionName": "1.0.0",
+    "FriendlyName": "Panorama Capture",
+    "Description": "Windows-only panoramic capture plugin with NVENC/FFmpeg integration and audio/video synchronization.",
+    "Category": "Rendering",
+    "CreatedBy": "AI Assistant",
+    "CreatedByURL": "https://openai.com",
+    "DocsURL": "",
+    "MarketplaceURL": "",
+    "SupportURL": "",
+    "EnabledByDefault": false,
+    "CanContainContent": true,
+    "IsBetaVersion": true,
+    "IsExperimentalVersion": true,
+    "Modules": [
+        {
+            "Name": "PanoramaCapture",
+            "Type": "Runtime",
+            "LoadingPhase": "Default",
+            "WhitelistPlatforms": [
+                "Win64"
+            ]
+        },
+        {
+            "Name": "PanoramaCaptureEditor",
+            "Type": "Editor",
+            "LoadingPhase": "PostEngineInit",
+            "WhitelistPlatforms": [
+                "Win64"
+            ]
+        }
+    ],
+    "Plugins": [
+        {
+            "Name": "RenderCore",
+            "Enabled": true
+        }
+    ],
+    "SupportedTargetPlatforms": ["Win64"],
+    "EngineVersion": "5.4.0",
+    "CanBeUsedWithUnrealVersionRange": "5.4.0-5.6.99"
+}

--- a/Plugins/PanoramaCapture/Shaders/PanoramaEquirectCS.usf
+++ b/Plugins/PanoramaCapture/Shaders/PanoramaEquirectCS.usf
@@ -1,0 +1,299 @@
+#include "/Engine/Public/Platform.ush"
+
+RWTexture2D<float4> OutputTexture;
+Texture2D FacePX;
+Texture2D FaceNX;
+Texture2D FacePY;
+Texture2D FaceNY;
+Texture2D FacePZ;
+Texture2D FaceNZ;
+SamplerState FaceSampler;
+
+cbuffer Parameters
+{
+    int2 OutputResolution;
+    int EyeIndex;
+    int GammaMode;
+    float Padding;
+};
+
+float4 SampleCubemap(float3 Direction)
+{
+    float3 AbsDirection = abs(Direction);
+    float2 UV;
+    float4 Sampled;
+
+    if (AbsDirection.x >= AbsDirection.y && AbsDirection.x >= AbsDirection.z)
+    {
+        if (Direction.x > 0)
+        {
+            UV = float2(-Direction.z, Direction.y) / AbsDirection.x;
+            Sampled = FacePX.SampleLevel(FaceSampler, UV * 0.5 + 0.5, 0);
+        }
+        else
+        {
+            UV = float2(Direction.z, Direction.y) / AbsDirection.x;
+            Sampled = FaceNX.SampleLevel(FaceSampler, UV * 0.5 + 0.5, 0);
+        }
+    }
+    else if (AbsDirection.y >= AbsDirection.x && AbsDirection.y >= AbsDirection.z)
+    {
+        if (Direction.y > 0)
+        {
+            UV = float2(Direction.x, -Direction.z) / AbsDirection.y;
+            Sampled = FacePY.SampleLevel(FaceSampler, UV * 0.5 + 0.5, 0);
+        }
+        else
+        {
+            UV = float2(Direction.x, Direction.z) / AbsDirection.y;
+            Sampled = FaceNY.SampleLevel(FaceSampler, UV * 0.5 + 0.5, 0);
+        }
+    }
+    else
+    {
+        if (Direction.z > 0)
+        {
+            UV = float2(Direction.x, Direction.y) / AbsDirection.z;
+            Sampled = FacePZ.SampleLevel(FaceSampler, UV * 0.5 + 0.5, 0);
+        }
+        else
+        {
+            UV = float2(-Direction.x, Direction.y) / AbsDirection.z;
+            Sampled = FaceNZ.SampleLevel(FaceSampler, UV * 0.5 + 0.5, 0);
+        }
+    }
+
+    return Sampled;
+}
+
+float3 ApplySeamFix(float3 Direction, float FixAmount)
+{
+    if (FixAmount <= 0.0)
+    {
+        return Direction;
+    }
+
+    float3 AbsDirection = abs(Direction);
+    float MaxComponent = max(max(AbsDirection.x, AbsDirection.y), AbsDirection.z);
+    if (MaxComponent <= 0.0)
+    {
+        return Direction;
+    }
+
+    float3 Normalized = Direction / MaxComponent;
+    float Scale = saturate(1.0 - FixAmount);
+    Normalized *= Scale;
+    return normalize(Normalized);
+}
+
+float3 ApplyGammaByMode(float3 LinearColor, int Mode)
+{
+    if (Mode == 0)
+    {
+        float3 Clamped = saturate(LinearColor);
+        return pow(Clamped, 1.0 / 2.2);
+    }
+
+    return saturate(LinearColor);
+}
+
+float3 ApplyGamma(float3 LinearColor)
+{
+    return ApplyGammaByMode(LinearColor, GammaMode);
+}
+
+[numthreads(8, 8, 1)]
+void MainCS(uint3 DispatchThreadId : SV_DispatchThreadID)
+{
+    if (DispatchThreadId.x >= OutputResolution.x || DispatchThreadId.y >= OutputResolution.y)
+    {
+        return;
+    }
+
+    float2 PixelCoord = (float2(DispatchThreadId.xy) + 0.5) / float2(OutputResolution);
+
+    float Phi = (PixelCoord.x * 2.0 - 1.0) * PI;
+    float Theta = (0.5 - PixelCoord.y) * PI;
+
+    float3 Direction;
+    Direction.x = cos(Theta) * sin(Phi);
+    Direction.y = sin(Theta);
+    Direction.z = cos(Theta) * cos(Phi);
+
+    Direction = ApplySeamFix(Direction, Padding);
+    float4 Sampled = SampleCubemap(normalize(Direction));
+    float3 Color = ApplyGamma(Sampled.rgb);
+
+    OutputTexture[DispatchThreadId.xy] = float4(Color, Sampled.a);
+}
+
+Texture2D<float4> NVENCSourceTexture;
+RWTexture2D<uint4> NVENCOutputTexture;
+
+cbuffer NVENCParameters
+{
+    int2 NVENCOutputResolution;
+    int2 NVENCSourceResolution;
+    int NVENCGammaMode;
+    int2 NVENCOffset;
+};
+
+float3 SampleNVENCSourceColor(int2 SourceCoord)
+{
+    float4 Sampled = NVENCSourceTexture.Load(int3(SourceCoord, 0));
+    float3 GammaCorrected = ApplyGammaByMode(Sampled.rgb, NVENCGammaMode);
+    return saturate(GammaCorrected);
+}
+
+float EncodeLuma8(float3 RGB)
+{
+    float YLinear = dot(RGB, float3(0.2126f, 0.7152f, 0.0722f));
+    float YByte = 16.0f + 219.0f * YLinear;
+    return clamp(YByte, 0.0f, 255.0f);
+}
+
+float EncodeLuma10(float3 RGB)
+{
+    float YLinear = dot(RGB, float3(0.2126f, 0.7152f, 0.0722f));
+    float YTenBit = 64.0f + 876.0f * YLinear;
+    return clamp(YTenBit, 0.0f, 1023.0f);
+}
+
+float2 EncodeChroma8(float3 RGB)
+{
+    float ULinear = dot(RGB, float3(-0.1146f, -0.3854f, 0.5000f));
+    float VLinear = dot(RGB, float3(0.5000f, -0.4542f, -0.0458f));
+    float UByte = 128.0f + 224.0f * ULinear;
+    float VByte = 128.0f + 224.0f * VLinear;
+    return clamp(float2(UByte, VByte), 0.0f, 255.0f);
+}
+
+float2 EncodeChroma10(float3 RGB)
+{
+    float ULinear = dot(RGB, float3(-0.1146f, -0.3854f, 0.5000f));
+    float VLinear = dot(RGB, float3(0.5000f, -0.4542f, -0.0458f));
+    float UTenBit = 512.0f + 896.0f * ULinear;
+    float VTenBit = 512.0f + 896.0f * VLinear;
+    return clamp(float2(UTenBit, VTenBit), 0.0f, 1023.0f);
+}
+
+[numthreads(8, 8, 1)]
+void ConvertToNVENCBGRA(uint3 DispatchThreadId : SV_DispatchThreadID)
+{
+    if (DispatchThreadId.x >= NVENCSourceResolution.x || DispatchThreadId.y >= NVENCSourceResolution.y)
+    {
+        return;
+    }
+
+    const int2 SourceCoord = int2(DispatchThreadId.xy);
+    const int2 DestCoord = SourceCoord + NVENCOffset;
+
+    if (DestCoord.x >= NVENCOutputResolution.x || DestCoord.y >= NVENCOutputResolution.y)
+    {
+        return;
+    }
+
+    float3 Color = SampleNVENCSourceColor(SourceCoord);
+    uint3 Quantized = (uint3)round(Color * 255.0f);
+    float AlphaFloat = saturate(NVENCSourceTexture.Load(int3(SourceCoord, 0)).a);
+    uint Alpha = (uint)round(AlphaFloat * 255.0f);
+
+    // NVENC expects BGRA ordering when submitting ARGB textures.
+    NVENCOutputTexture[DestCoord] = uint4(Quantized.b, Quantized.g, Quantized.r, Alpha);
+}
+
+RWTexture2D<uint> NVENCPlanarYTexture;
+RWTexture2D<uint2> NVENCPlanarUVTexture;
+
+cbuffer NVENCPlanarParameters
+{
+    int2 NVENCYResolution;
+    int2 NVENCSourceResolutionPlanar;
+    int2 NVENCOffsetPlanar;
+    int2 NVENCChromaResolution;
+    int2 NVENCChromaOffset;
+    int NVENCPlanarGammaMode;
+    int NVENCIs10Bit;
+};
+
+void WritePlanarLuma(int2 DestCoord, float EncodedValue)
+{
+    if (DestCoord.x < 0 || DestCoord.y < 0 || DestCoord.x >= NVENCYResolution.x || DestCoord.y >= NVENCYResolution.y)
+    {
+        return;
+    }
+    NVENCPlanarYTexture[DestCoord] = (uint)round(EncodedValue);
+}
+
+[numthreads(8, 8, 1)]
+void ConvertToNVENCPlanar(uint3 DispatchThreadId : SV_DispatchThreadID)
+{
+    if (DispatchThreadId.x >= NVENCChromaResolution.x || DispatchThreadId.y >= NVENCChromaResolution.y)
+    {
+        return;
+    }
+
+    const int2 BlockCoord = int2(DispatchThreadId.xy);
+    const int2 SourceBase = BlockCoord * 2;
+
+    if (SourceBase.x >= NVENCSourceResolutionPlanar.x || SourceBase.y >= NVENCSourceResolutionPlanar.y)
+    {
+        return;
+    }
+
+    int2 SampleCoords[4];
+    SampleCoords[0] = SourceBase;
+    SampleCoords[1] = SourceBase + int2(1, 0);
+    SampleCoords[2] = SourceBase + int2(0, 1);
+    SampleCoords[3] = SourceBase + int2(1, 1);
+
+    float3 Colors[4];
+    [unroll]
+    for (int Index = 0; Index < 4; ++Index)
+    {
+        int2 Clamped = SampleCoords[Index];
+        Clamped.x = clamp(Clamped.x, 0, NVENCSourceResolutionPlanar.x - 1);
+        Clamped.y = clamp(Clamped.y, 0, NVENCSourceResolutionPlanar.y - 1);
+        float4 Sampled = NVENCSourceTexture.Load(int3(Clamped, 0));
+        float3 GammaCorrected = ApplyGammaByMode(Sampled.rgb, NVENCPlanarGammaMode);
+        Colors[Index] = saturate(GammaCorrected);
+    }
+
+    const int2 DestBase = BlockCoord * 2 + NVENCOffsetPlanar;
+
+    if (NVENCIs10Bit != 0)
+    {
+        WritePlanarLuma(DestBase, EncodeLuma10(Colors[0]));
+        WritePlanarLuma(DestBase + int2(1, 0), EncodeLuma10(Colors[1]));
+        WritePlanarLuma(DestBase + int2(0, 1), EncodeLuma10(Colors[2]));
+        WritePlanarLuma(DestBase + int2(1, 1), EncodeLuma10(Colors[3]));
+    }
+    else
+    {
+        WritePlanarLuma(DestBase, EncodeLuma8(Colors[0]));
+        WritePlanarLuma(DestBase + int2(1, 0), EncodeLuma8(Colors[1]));
+        WritePlanarLuma(DestBase + int2(0, 1), EncodeLuma8(Colors[2]));
+        WritePlanarLuma(DestBase + int2(1, 1), EncodeLuma8(Colors[3]));
+    }
+
+    float2 ChromaAccum = float2(0.0f, 0.0f);
+    [unroll]
+    for (int Index = 0; Index < 4; ++Index)
+    {
+        if (NVENCIs10Bit != 0)
+        {
+            ChromaAccum += EncodeChroma10(Colors[Index]);
+        }
+        else
+        {
+            ChromaAccum += EncodeChroma8(Colors[Index]);
+        }
+    }
+
+    float2 Averaged = ChromaAccum * 0.25f;
+    const int2 DestChromaCoord = BlockCoord + NVENCChromaOffset;
+    if (DestChromaCoord.x >= 0 && DestChromaCoord.y >= 0 && DestChromaCoord.x < NVENCChromaResolution.x && DestChromaCoord.y < NVENCChromaResolution.y)
+    {
+        NVENCPlanarUVTexture[DestChromaCoord] = (uint2)round(Averaged);
+    }
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/PanoramaCapture.Build.cs
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/PanoramaCapture.Build.cs
@@ -1,0 +1,65 @@
+using UnrealBuildTool;
+using System.IO;
+
+public class PanoramaCapture : ModuleRules
+{
+    public PanoramaCapture(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "CoreUObject",
+                "Engine",
+                "RenderCore",
+                "RHI",
+                "Projects",
+                "AudioMixer",
+                "SlateCore"
+            });
+
+        PrivateDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "ApplicationCore",
+                "Json",
+                "JsonUtilities",
+                "ImageWrapper"
+            });
+
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            string ThirdPartyDir = Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "Win64");
+            PublicDefinitions.Add("PANORAMA_WITH_NVENC=1");
+            PublicAdditionalLibraries.AddRange(new string[]
+            {
+                // NVENC and FFmpeg libraries are expected to live under ThirdParty
+                Path.Combine(ThirdPartyDir, "nvEncodeAPI64.lib"),
+                Path.Combine(ThirdPartyDir, "avcodec.lib"),
+                Path.Combine(ThirdPartyDir, "avformat.lib"),
+                Path.Combine(ThirdPartyDir, "avutil.lib")
+            });
+            PublicIncludePaths.Add(ThirdPartyDir);
+        }
+        else
+        {
+            PublicDefinitions.Add("PANORAMA_WITH_NVENC=0");
+        }
+
+        PublicIncludePaths.AddRange(
+            new string[]
+            {
+                Path.Combine(ModuleDirectory, "Public")
+            });
+
+        PrivateIncludePaths.AddRange(
+            new string[]
+            {
+                Path.Combine(ModuleDirectory, "Private")
+            });
+
+        RuntimeDependencies.Add(Path.Combine(ModuleDirectory, "..", "..", "Shaders", "PanoramaEquirectCS.usf"));
+    }
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureAudio.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureAudio.cpp
@@ -1,0 +1,333 @@
+#include "PanoramaCaptureAudio.h"
+#include "PanoramaCaptureLog.h"
+#include "AudioDevice.h"
+#if WITH_AUDIOMIXER
+#include "AudioMixerSubmix.h"
+#endif
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Sound/SoundSubmix.h"
+#include "Engine/World.h"
+#include "Serialization/BufferArchive.h"
+#include "HAL/PlatformTime.h"
+
+namespace
+{
+    static constexpr int32 BitsPerSample = 16;
+}
+
+#if WITH_AUDIOMIXER
+class FPanoramaAudioRecorder::FSubmixCaptureListener : public Audio::ISubmixBufferListener
+{
+public:
+    explicit FSubmixCaptureListener(FPanoramaAudioRecorder& InOwner)
+        : Owner(InOwner)
+    {
+    }
+
+    virtual void OnNewSubmixBuffer(USoundSubmix* OwningSubmix, float* AudioData, int32 NumSamples, int32 NumChannels, const int32 SampleRate, double /*AudioClock*/, bool /*bIsPaused*/) override
+    {
+        Owner.HandleSubmixBuffer(AudioData, NumSamples, NumChannels, SampleRate);
+    }
+
+    virtual bool IsSubmixListenerEnabled() const override
+    {
+        return true;
+    }
+
+private:
+    FPanoramaAudioRecorder& Owner;
+};
+#endif // WITH_AUDIOMIXER
+
+FPanoramaAudioRecorder::FPanoramaAudioRecorder()
+    : bIsRecording(false)
+    , RecordingDurationSeconds(0.0)
+    , CapturedSampleRate(0)
+    , CapturedNumChannels(0)
+    , TotalFramesCaptured(0)
+    , CaptureClockStartSeconds(0.0)
+    , RecordingStartSeconds(0.0)
+    , LastPacketPTS(0.0)
+    , SmoothedDriftSeconds(0.0)
+{
+}
+
+FPanoramaAudioRecorder::~FPanoramaAudioRecorder()
+{
+    Shutdown();
+}
+
+void FPanoramaAudioRecorder::Initialize(const FPanoramicAudioSettings& Settings, const FString& OutputDirectory, UWorld* InWorld)
+{
+    CurrentSettings = Settings;
+    TargetDirectory = OutputDirectory;
+    IFileManager::Get().MakeDirectory(*TargetDirectory, true);
+    WaveFilePath = FPaths::Combine(TargetDirectory, TEXT("PanoramaAudio.wav"));
+    World = InWorld;
+    SubmixToRecord = nullptr;
+    ActiveRecordingSubmix.Reset();
+    ResetCaptureData();
+}
+
+void FPanoramaAudioRecorder::Shutdown()
+{
+    StopRecording();
+    FinalizeWaveFile();
+    ResetCaptureData();
+    WaveFilePath.Reset();
+    World.Reset();
+    SubmixToRecord.Reset();
+    ActiveRecordingSubmix.Reset();
+    SubmixListener.Reset();
+}
+
+void FPanoramaAudioRecorder::StartRecording()
+{
+    if (bIsRecording)
+    {
+        return;
+    }
+
+    if (!CurrentSettings.bCaptureAudio)
+    {
+        UE_LOG(LogPanoramaCapture, Log, TEXT("Audio capture disabled - skipping start"));
+        return;
+    }
+
+#if WITH_AUDIOMIXER
+    RecordingStartSeconds = FPlatformTime::Seconds();
+    ResetCaptureData();
+    RegisterListener();
+    if (bIsRecording)
+    {
+        UE_LOG(LogPanoramaCapture, Log, TEXT("Audio recording started at %d Hz (%d channels)"), CapturedSampleRate, CapturedNumChannels);
+    }
+    else
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to start audio capture - no valid submix or audio device."));
+    }
+#else
+    UE_LOG(LogPanoramaCapture, Warning, TEXT("AudioMixer not available - audio will not be captured"));
+#endif
+}
+
+void FPanoramaAudioRecorder::StopRecording()
+{
+    if (!bIsRecording)
+    {
+        return;
+    }
+
+    UE_LOG(LogPanoramaCapture, Log, TEXT("Stopping audio recording"));
+    UnregisterListener();
+    RecordingDurationSeconds = LastPacketPTS;
+    bIsRecording = false;
+}
+
+void FPanoramaAudioRecorder::Tick(float DeltaSeconds)
+{
+    UE_UNUSED(DeltaSeconds);
+    // Duration is derived from captured sample counts; no work required per tick.
+}
+
+void FPanoramaAudioRecorder::ConsumeAudioPackets(TArray<FPanoramaAudioPacket>& OutPackets)
+{
+    FScopeLock Lock(&AudioDataCriticalSection);
+    OutPackets = MoveTemp(PendingPackets);
+    PendingPackets.Reset();
+}
+
+void FPanoramaAudioRecorder::FinalizeWaveFile()
+{
+    TArray<uint8> PCMBuffer;
+    int32 NumChannels = CurrentSettings.NumChannels;
+    int32 SampleRate = CurrentSettings.SampleRate;
+
+    {
+        FScopeLock Lock(&AudioDataCriticalSection);
+        if (AccumulatedPCMData.Num() == 0)
+        {
+            return;
+        }
+
+        PCMBuffer = AccumulatedPCMData;
+        NumChannels = (CapturedNumChannels > 0) ? CapturedNumChannels : NumChannels;
+        SampleRate = (CapturedSampleRate > 0) ? CapturedSampleRate : SampleRate;
+    }
+
+    const int32 BytesPerSample = BitsPerSample / 8;
+    const int32 DataSize = PCMBuffer.Num();
+    const int32 ByteRate = SampleRate * NumChannels * BytesPerSample;
+    const int16 BlockAlign = NumChannels * BytesPerSample;
+    const int32 ChunkSize = 36 + DataSize;
+
+    FBufferArchive WaveData;
+    WaveData.Reserve(PCMBuffer.Num() + 44);
+
+    auto WriteUInt32 = [&WaveData](uint32 Value)
+    {
+        WaveData << Value;
+    };
+
+    auto WriteUInt16 = [&WaveData](uint16 Value)
+    {
+        WaveData << Value;
+    };
+
+    const uint32 RIFF = 0x46464952; // 'RIFF'
+    const uint32 WAVE = 0x45564157; // 'WAVE'
+    const uint32 FMT  = 0x20746D66; // 'fmt '
+    const uint32 DATA = 0x61746164; // 'data'
+
+    WriteUInt32(RIFF);
+    WriteUInt32(static_cast<uint32>(ChunkSize));
+    WriteUInt32(WAVE);
+    WriteUInt32(FMT);
+    WriteUInt32(16); // PCM chunk size
+    WriteUInt16(1);  // PCM format
+    WriteUInt16(static_cast<uint16>(NumChannels));
+    WriteUInt32(static_cast<uint32>(SampleRate));
+    WriteUInt32(static_cast<uint32>(ByteRate));
+    WriteUInt16(static_cast<uint16>(BlockAlign));
+    WriteUInt16(static_cast<uint16>(BitsPerSample));
+    WriteUInt32(DATA);
+    WriteUInt32(static_cast<uint32>(DataSize));
+
+    if (PCMBuffer.Num() > 0)
+    {
+        WaveData.Append(PCMBuffer.GetData(), PCMBuffer.Num());
+    }
+
+    if (!FFileHelper::SaveArrayToFile(WaveData, *WaveFilePath))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to write WAV file to %s"), *WaveFilePath);
+    }
+
+    WaveData.FlushCache();
+    WaveData.Empty();
+
+    {
+        FScopeLock Lock(&AudioDataCriticalSection);
+        AccumulatedPCMData.Reset();
+        PendingPackets.Reset();
+    }
+}
+
+void FPanoramaAudioRecorder::RegisterListener()
+{
+#if WITH_AUDIOMIXER
+    if (!World.IsValid())
+    {
+        return;
+    }
+
+    AudioDeviceHandle = World->GetAudioDevice();
+    FAudioDevice* AudioDevice = AudioDeviceHandle.GetAudioDevice();
+    if (!AudioDevice)
+    {
+        return;
+    }
+
+    USoundSubmix* TargetSubmix = SubmixToRecord.Get();
+    if (!TargetSubmix)
+    {
+        TargetSubmix = AudioDevice->GetMainSubmixObject();
+    }
+
+    if (!TargetSubmix)
+    {
+        return;
+    }
+
+    if (!SubmixListener.IsValid())
+    {
+        SubmixListener = MakeShared<FSubmixCaptureListener, ESPMode::ThreadSafe>(*this);
+    }
+
+    AudioDevice->RegisterSubmixBufferListener(SubmixListener.Get(), TargetSubmix);
+    ActiveRecordingSubmix = TargetSubmix;
+    bIsRecording = true;
+#endif
+}
+
+void FPanoramaAudioRecorder::UnregisterListener()
+{
+#if WITH_AUDIOMIXER
+    if (FAudioDevice* AudioDevice = AudioDeviceHandle.GetAudioDevice())
+    {
+        if (ActiveRecordingSubmix.IsValid() && SubmixListener.IsValid())
+        {
+            AudioDevice->UnregisterSubmixBufferListener(SubmixListener.Get(), ActiveRecordingSubmix.Get());
+        }
+    }
+
+    AudioDeviceHandle = FAudioDeviceHandle();
+    ActiveRecordingSubmix.Reset();
+#endif
+}
+
+void FPanoramaAudioRecorder::ResetCaptureData()
+{
+    FScopeLock Lock(&AudioDataCriticalSection);
+    PendingPackets.Reset();
+    AccumulatedPCMData.Reset();
+    RecordingDurationSeconds = 0.0;
+    TotalFramesCaptured = 0;
+    CapturedSampleRate = CurrentSettings.SampleRate;
+    CapturedNumChannels = CurrentSettings.NumChannels;
+    LastPacketPTS = 0.0;
+    SmoothedDriftSeconds = 0.0;
+}
+
+void FPanoramaAudioRecorder::AppendPCMData(const FPanoramaAudioPacket& Packet)
+{
+    AccumulatedPCMData.Append(Packet.PCMData);
+}
+
+void FPanoramaAudioRecorder::HandleSubmixBuffer(float* AudioData, int32 NumSamples, int32 NumChannels, int32 InSampleRate)
+{
+#if WITH_AUDIOMIXER
+    if (!bIsRecording || NumSamples <= 0 || NumChannels <= 0)
+    {
+        return;
+    }
+
+    const int32 BytesPerSample = BitsPerSample / 8;
+    const int32 NumFrames = NumSamples / NumChannels;
+    FPanoramaAudioPacket Packet;
+    Packet.NumChannels = NumChannels;
+    Packet.SampleRate = InSampleRate;
+    const double FrameOffsetSeconds = (InSampleRate > 0) ? static_cast<double>(TotalFramesCaptured) / static_cast<double>(InSampleRate) : 0.0;
+    const double BaseOffsetSeconds = RecordingStartSeconds - CaptureClockStartSeconds;
+    Packet.TimestampSeconds = FMath::Max(0.0, BaseOffsetSeconds) + FrameOffsetSeconds;
+    const double PacketDurationSeconds = (InSampleRate > 0) ? static_cast<double>(NumFrames) / static_cast<double>(InSampleRate) : 0.0;
+    const double RealClockSeconds = FPlatformTime::Seconds() - CaptureClockStartSeconds;
+    const double ExpectedEnd = Packet.TimestampSeconds + PacketDurationSeconds;
+    const double Drift = RealClockSeconds - ExpectedEnd;
+    SmoothedDriftSeconds = FMath::Clamp(FMath::Lerp(SmoothedDriftSeconds, Drift, 0.05), -0.25, 0.25);
+    Packet.TimestampSeconds = FMath::Max(0.0, Packet.TimestampSeconds + SmoothedDriftSeconds);
+    Packet.PCMData.SetNumUninitialized(NumSamples * BytesPerSample);
+
+    int16* DestBuffer = reinterpret_cast<int16*>(Packet.PCMData.GetData());
+    for (int32 SampleIndex = 0; SampleIndex < NumSamples; ++SampleIndex)
+    {
+        const float Clamped = FMath::Clamp(AudioData[SampleIndex], -1.0f, 1.0f);
+        DestBuffer[SampleIndex] = static_cast<int16>(Clamped * 32767.0f);
+    }
+
+    {
+        FScopeLock Lock(&AudioDataCriticalSection);
+        const double PacketDuration = Packet.GetDurationSeconds();
+        LastPacketPTS = Packet.TimestampSeconds + PacketDuration;
+        RecordingDurationSeconds = FMath::Max(RecordingDurationSeconds, LastPacketPTS);
+        FPanoramaAudioPacket& StoredPacket = PendingPackets.Emplace_GetRef(MoveTemp(Packet));
+        AppendPCMData(StoredPacket);
+    }
+
+    TotalFramesCaptured += NumFrames;
+    CapturedSampleRate = InSampleRate;
+    CapturedNumChannels = NumChannels;
+#endif
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureAudio.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureAudio.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PanoramaCaptureTypes.h"
+#include "AudioDeviceHandle.h"
+#include "HAL/CriticalSection.h"
+
+class USoundSubmix;
+class UWorld;
+
+namespace Audio
+{
+    class ISubmixBufferListener;
+}
+
+/** Handles AudioMixer submix recording and WAV output. */
+class FPanoramaAudioRecorder
+{
+public:
+    FPanoramaAudioRecorder();
+    ~FPanoramaAudioRecorder();
+
+    void Initialize(const FPanoramicAudioSettings& Settings, const FString& OutputDirectory, UWorld* InWorld);
+    void Shutdown();
+
+    void StartRecording();
+    void StopRecording();
+
+    void Tick(float DeltaSeconds);
+
+    /** Retrieve PCM packets captured since last call. */
+    void ConsumeAudioPackets(TArray<FPanoramaAudioPacket>& OutPackets);
+
+    FString GetWaveFilePath() const { return WaveFilePath; }
+    double GetRecordingDurationSeconds() const { return RecordingDurationSeconds; }
+    void SetSubmixToRecord(USoundSubmix* InSubmix) { SubmixToRecord = InSubmix; }
+    void SetCaptureStartTime(double InCaptureStartSeconds)
+    {
+        CaptureClockStartSeconds = InCaptureStartSeconds;
+        SmoothedDriftSeconds = 0.0;
+    }
+    double GetLastPacketPTS() const { return LastPacketPTS; }
+
+    bool IsRecording() const { return bIsRecording; }
+
+    /** Writes the accumulated PCM buffer to disk as a WAV file. */
+    void FinalizeWaveFile();
+
+private:
+    class FSubmixCaptureListener;
+
+    void RegisterListener();
+    void UnregisterListener();
+    void ResetCaptureData();
+    void AppendPCMData(const FPanoramaAudioPacket& Packet);
+    void HandleSubmixBuffer(float* AudioData, int32 NumSamples, int32 NumChannels, int32 InSampleRate);
+
+    FPanoramicAudioSettings CurrentSettings;
+    FString TargetDirectory;
+    FString WaveFilePath;
+
+    bool bIsRecording;
+
+    TWeakObjectPtr<UWorld> World;
+    TWeakObjectPtr<USoundSubmix> SubmixToRecord;
+    TWeakObjectPtr<USoundSubmix> ActiveRecordingSubmix;
+
+    FAudioDeviceHandle AudioDeviceHandle;
+    TSharedPtr<FSubmixCaptureListener, ESPMode::ThreadSafe> SubmixListener;
+
+    FCriticalSection AudioDataCriticalSection;
+    TArray<FPanoramaAudioPacket> PendingPackets;
+    TArray<uint8> AccumulatedPCMData;
+
+    double RecordingDurationSeconds;
+    int32 CapturedSampleRate;
+    int32 CapturedNumChannels;
+    int64 TotalFramesCaptured;
+    double CaptureClockStartSeconds;
+    double RecordingStartSeconds;
+    double LastPacketPTS;
+    double SmoothedDriftSeconds;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureColorConversion.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureColorConversion.cpp
@@ -1,0 +1,271 @@
+#include "PanoramaCaptureColorConversion.h"
+#include "Math/Float16Color.h"
+
+namespace PanoramaCapture
+{
+namespace Color
+{
+namespace
+{
+    FORCEINLINE uint8 ClampToByte(float Value)
+    {
+        return static_cast<uint8>(FMath::Clamp(FMath::RoundToInt(Value), 0, 255));
+    }
+
+    FORCEINLINE uint16 ClampToTenBit(float Value)
+    {
+        return static_cast<uint16>(FMath::Clamp(FMath::RoundToInt(Value), 0, 1023));
+    }
+
+    void ExtractGammaAdjustedRGB(const FFloat16Color& Pixel, EPanoramaGamma GammaMode, float& OutR, float& OutG, float& OutB, float& OutA)
+    {
+        const FLinearColor LinearColor(Pixel.R.GetFloat(), Pixel.G.GetFloat(), Pixel.B.GetFloat(), Pixel.A.GetFloat());
+        OutA = FMath::Clamp(LinearColor.A, 0.0f, 1.0f);
+
+        if (GammaMode == EPanoramaGamma::SRGB)
+        {
+            const FColor SRGBColor = LinearColor.GetClamped().ToFColorSRGB();
+            OutR = static_cast<float>(SRGBColor.R) / 255.0f;
+            OutG = static_cast<float>(SRGBColor.G) / 255.0f;
+            OutB = static_cast<float>(SRGBColor.B) / 255.0f;
+        }
+        else
+        {
+            OutR = FMath::Clamp(LinearColor.R, 0.0f, 1.0f);
+            OutG = FMath::Clamp(LinearColor.G, 0.0f, 1.0f);
+            OutB = FMath::Clamp(LinearColor.B, 0.0f, 1.0f);
+        }
+    }
+}
+
+bool ConvertLinearToNV12Planes(const TArray<FFloat16Color>& SourcePixels, const FIntPoint& Resolution, EPanoramaGamma GammaMode, FNV12PlaneBuffers& OutPlanes)
+{
+    const int32 Width = Resolution.X;
+    const int32 Height = Resolution.Y;
+    if (Width <= 0 || Height <= 0 || (Width % 2) != 0 || (Height % 2) != 0)
+    {
+        return false;
+    }
+
+    const int32 ExpectedPixelCount = Width * Height;
+    if (SourcePixels.Num() != ExpectedPixelCount)
+    {
+        return false;
+    }
+
+    OutPlanes.Resolution = Resolution;
+    OutPlanes.YPlane.SetNumUninitialized(ExpectedPixelCount);
+    OutPlanes.UVPlane.SetNumUninitialized((Width * Height) / 2);
+
+    const int32 BlockWidth = Width / 2;
+    const int32 BlockHeight = Height / 2;
+
+    TArray<float> UAccumulator;
+    TArray<float> VAccumulator;
+    TArray<int32> SampleCounts;
+    UAccumulator.SetNumZeroed(BlockWidth * BlockHeight);
+    VAccumulator.SetNumZeroed(BlockWidth * BlockHeight);
+    SampleCounts.SetNumZeroed(BlockWidth * BlockHeight);
+
+    uint8* YPlanePtr = OutPlanes.YPlane.GetData();
+
+    for (int32 Y = 0; Y < Height; ++Y)
+    {
+        for (int32 X = 0; X < Width; ++X)
+        {
+            const int32 PixelIndex = Y * Width + X;
+            const FFloat16Color& Pixel = SourcePixels[PixelIndex];
+
+            float R;
+            float G;
+            float B;
+            float A;
+            ExtractGammaAdjustedRGB(Pixel, GammaMode, R, G, B, A);
+            UE_UNUSED(A);
+
+            const float YLinear = 0.2126f * R + 0.7152f * G + 0.0722f * B;
+            const float ULinear = -0.1146f * R - 0.3854f * G + 0.5000f * B;
+            const float VLinear = 0.5000f * R - 0.4542f * G - 0.0458f * B;
+
+            const float YByte = 16.0f + 219.0f * YLinear;
+            const float UByte = 128.0f + 224.0f * ULinear;
+            const float VByte = 128.0f + 224.0f * VLinear;
+
+            YPlanePtr[PixelIndex] = ClampToByte(YByte);
+
+            const int32 BlockX = X / 2;
+            const int32 BlockY = Y / 2;
+            const int32 BlockIndex = BlockY * BlockWidth + BlockX;
+            UAccumulator[BlockIndex] += ClampToByte(UByte);
+            VAccumulator[BlockIndex] += ClampToByte(VByte);
+            SampleCounts[BlockIndex] += 1;
+        }
+    }
+
+    uint8* UVPlanePtr = OutPlanes.UVPlane.GetData();
+    for (int32 BlockY = 0; BlockY < BlockHeight; ++BlockY)
+    {
+        uint8* RowPtr = UVPlanePtr + (BlockY * Width);
+        for (int32 BlockX = 0; BlockX < BlockWidth; ++BlockX)
+        {
+            const int32 BlockIndex = BlockY * BlockWidth + BlockX;
+            const int32 SampleCount = FMath::Max(1, SampleCounts[BlockIndex]);
+            const float UAverage = UAccumulator[BlockIndex] / static_cast<float>(SampleCount);
+            const float VAverage = VAccumulator[BlockIndex] / static_cast<float>(SampleCount);
+            RowPtr[BlockX * 2] = ClampToByte(UAverage);
+            RowPtr[BlockX * 2 + 1] = ClampToByte(VAverage);
+        }
+    }
+
+    return true;
+}
+
+void CollapsePlanesToNV12(const FNV12PlaneBuffers& Planes, TArray<uint8>& OutData)
+{
+    OutData.SetNumUninitialized(Planes.YPlane.Num() + Planes.UVPlane.Num());
+    if (Planes.YPlane.Num() > 0)
+    {
+        FMemory::Memcpy(OutData.GetData(), Planes.YPlane.GetData(), Planes.YPlane.Num());
+    }
+    if (Planes.UVPlane.Num() > 0)
+    {
+        FMemory::Memcpy(OutData.GetData() + Planes.YPlane.Num(), Planes.UVPlane.GetData(), Planes.UVPlane.Num());
+    }
+}
+
+bool ConvertLinearToP010Planes(const TArray<FFloat16Color>& SourcePixels, const FIntPoint& Resolution, EPanoramaGamma GammaMode, FP010PlaneBuffers& OutPlanes)
+{
+    const int32 Width = Resolution.X;
+    const int32 Height = Resolution.Y;
+    if (Width <= 0 || Height <= 0 || (Width % 2) != 0 || (Height % 2) != 0)
+    {
+        return false;
+    }
+
+    const int32 ExpectedPixelCount = Width * Height;
+    if (SourcePixels.Num() != ExpectedPixelCount)
+    {
+        return false;
+    }
+
+    OutPlanes.Resolution = Resolution;
+    OutPlanes.YPlane.SetNumUninitialized(ExpectedPixelCount);
+    OutPlanes.UVPlane.SetNumUninitialized((Width * Height) / 2);
+
+    const int32 BlockWidth = Width / 2;
+    const int32 BlockHeight = Height / 2;
+
+    TArray<float> UAccumulator;
+    TArray<float> VAccumulator;
+    TArray<int32> SampleCounts;
+    UAccumulator.SetNumZeroed(BlockWidth * BlockHeight);
+    VAccumulator.SetNumZeroed(BlockWidth * BlockHeight);
+    SampleCounts.SetNumZeroed(BlockWidth * BlockHeight);
+
+    uint16* YPlanePtr = OutPlanes.YPlane.GetData();
+
+    for (int32 Y = 0; Y < Height; ++Y)
+    {
+        for (int32 X = 0; X < Width; ++X)
+        {
+            const int32 PixelIndex = Y * Width + X;
+            const FFloat16Color& Pixel = SourcePixels[PixelIndex];
+
+            float R;
+            float G;
+            float B;
+            float A;
+            ExtractGammaAdjustedRGB(Pixel, GammaMode, R, G, B, A);
+            UE_UNUSED(A);
+
+            const float YLinear = 0.2126f * R + 0.7152f * G + 0.0722f * B;
+            const float ULinear = -0.1146f * R - 0.3854f * G + 0.5000f * B;
+            const float VLinear = 0.5000f * R - 0.4542f * G - 0.0458f * B;
+
+            const float YTenBit = 64.0f + 876.0f * YLinear;
+            const float UTenBit = 512.0f + 896.0f * ULinear;
+            const float VTenBit = 512.0f + 896.0f * VLinear;
+
+            YPlanePtr[PixelIndex] = ClampToTenBit(YTenBit);
+
+            const int32 BlockX = X / 2;
+            const int32 BlockY = Y / 2;
+            const int32 BlockIndex = BlockY * BlockWidth + BlockX;
+            UAccumulator[BlockIndex] += ClampToTenBit(UTenBit);
+            VAccumulator[BlockIndex] += ClampToTenBit(VTenBit);
+            SampleCounts[BlockIndex] += 1;
+        }
+    }
+
+    uint16* UVPlanePtr = OutPlanes.UVPlane.GetData();
+    for (int32 BlockY = 0; BlockY < BlockHeight; ++BlockY)
+    {
+        uint16* RowPtr = UVPlanePtr + (BlockY * Width);
+        for (int32 BlockX = 0; BlockX < BlockWidth; ++BlockX)
+        {
+            const int32 BlockIndex = BlockY * BlockWidth + BlockX;
+            const int32 SampleCount = FMath::Max(1, SampleCounts[BlockIndex]);
+            const float UAverage = UAccumulator[BlockIndex] / static_cast<float>(SampleCount);
+            const float VAverage = VAccumulator[BlockIndex] / static_cast<float>(SampleCount);
+            RowPtr[BlockX * 2] = ClampToTenBit(UAverage);
+            RowPtr[BlockX * 2 + 1] = ClampToTenBit(VAverage);
+        }
+    }
+
+    return true;
+}
+
+void CollapsePlanesToP010(const FP010PlaneBuffers& Planes, TArray<uint8>& OutData)
+{
+    const int32 YBytes = Planes.YPlane.Num() * sizeof(uint16);
+    const int32 UVBytes = Planes.UVPlane.Num() * sizeof(uint16);
+    OutData.SetNumUninitialized(YBytes + UVBytes);
+    if (YBytes > 0)
+    {
+        FMemory::Memcpy(OutData.GetData(), Planes.YPlane.GetData(), YBytes);
+    }
+    if (UVBytes > 0)
+    {
+        FMemory::Memcpy(OutData.GetData() + YBytes, Planes.UVPlane.GetData(), UVBytes);
+    }
+}
+
+bool ConvertLinearToBGRAPayload(const TArray<FFloat16Color>& SourcePixels, const FIntPoint& Resolution, EPanoramaGamma GammaMode, TArray<uint8>& OutData)
+{
+    const int32 Width = Resolution.X;
+    const int32 Height = Resolution.Y;
+    if (Width <= 0 || Height <= 0)
+    {
+        return false;
+    }
+
+    const int32 ExpectedPixelCount = Width * Height;
+    if (SourcePixels.Num() != ExpectedPixelCount)
+    {
+        return false;
+    }
+
+    OutData.SetNumUninitialized(ExpectedPixelCount * 4);
+
+    uint8* DestPtr = OutData.GetData();
+    for (int32 Index = 0; Index < ExpectedPixelCount; ++Index)
+    {
+        const FFloat16Color& Pixel = SourcePixels[Index];
+        float R;
+        float G;
+        float B;
+        float A;
+        ExtractGammaAdjustedRGB(Pixel, GammaMode, R, G, B, A);
+
+        DestPtr[Index * 4 + 0] = ClampToByte(B * 255.0f);
+        DestPtr[Index * 4 + 1] = ClampToByte(G * 255.0f);
+        DestPtr[Index * 4 + 2] = ClampToByte(R * 255.0f);
+        DestPtr[Index * 4 + 3] = ClampToByte(A * 255.0f);
+    }
+
+    return true;
+}
+
+}
+}
+

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureColorConversion.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureColorConversion.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PanoramaCaptureTypes.h"
+#include "Math/Float16Color.h"
+
+namespace PanoramaCapture
+{
+namespace Color
+{
+    struct FNV12PlaneBuffers
+    {
+        FIntPoint Resolution = FIntPoint::ZeroValue;
+        TArray<uint8> YPlane;
+        TArray<uint8> UVPlane;
+    };
+
+    struct FP010PlaneBuffers
+    {
+        FIntPoint Resolution = FIntPoint::ZeroValue;
+        TArray<uint16> YPlane;
+        TArray<uint16> UVPlane;
+    };
+
+    /** Converts linear HDR pixels to NV12 planes with optional gamma processing. */
+    bool ConvertLinearToNV12Planes(const TArray<FFloat16Color>& SourcePixels, const FIntPoint& Resolution, EPanoramaGamma GammaMode, FNV12PlaneBuffers& OutPlanes);
+
+    /** Flattens NV12 planes into a contiguous Y + UV byte payload. */
+    void CollapsePlanesToNV12(const FNV12PlaneBuffers& Planes, TArray<uint8>& OutData);
+
+    /** Converts linear HDR pixels to P010 planes with optional gamma processing. */
+    bool ConvertLinearToP010Planes(const TArray<FFloat16Color>& SourcePixels, const FIntPoint& Resolution, EPanoramaGamma GammaMode, FP010PlaneBuffers& OutPlanes);
+
+    /** Flattens P010 planes into a contiguous Y + UV payload (16-bit per sample). */
+    void CollapsePlanesToP010(const FP010PlaneBuffers& Planes, TArray<uint8>& OutData);
+
+    /** Converts linear HDR pixels directly into a BGRA8 byte payload. */
+    bool ConvertLinearToBGRAPayload(const TArray<FFloat16Color>& SourcePixels, const FIntPoint& Resolution, EPanoramaGamma GammaMode, TArray<uint8>& OutData);
+}
+}
+

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureComponent.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureComponent.cpp
@@ -1,0 +1,381 @@
+#include "PanoramaCaptureComponent.h"
+#include "PanoramaCaptureManager.h"
+#include "PanoramaCaptureRenderer.h"
+#include "PanoramaCaptureTypes.h"
+#include "Components/StaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/World.h"
+#include "Kismet/GameplayStatics.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "UObject/ConstructorHelpers.h"
+#include "GameFramework/Actor.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Engine/Scene.h"
+#include "Sound/SoundSubmix.h"
+
+namespace PanoramaCapture
+{
+    static const FName PreviewMeshName(TEXT("PanoramaPreviewMesh"));
+    static const TArray<FVector> Directions = {
+        FVector::ForwardVector,
+        FVector::BackwardVector,
+        FVector::RightVector,
+        FVector::LeftVector,
+        FVector::UpVector,
+        FVector::DownVector
+    };
+
+    static FRotator DirectionToRotation(const FVector& Direction)
+    {
+        return Direction.Rotation();
+    }
+}
+
+UPanoramaCaptureComponent::UPanoramaCaptureComponent()
+    : OutputDirectory(TEXT(""))
+    , PreviewMaterialTemplate(nullptr)
+    , bPreviewRequested(true)
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.TickGroup = TG_PostUpdateWork;
+    VideoSettings.Resolution = FIntPoint(7680, 3840);
+    CachedStatus = FPanoramicCaptureStatus();
+}
+
+void UPanoramaCaptureComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (!CaptureManager.IsValid())
+    {
+        CaptureManager = MakeShared<FPanoramaCaptureManager>();
+        CaptureManager->Initialize(this, VideoSettings, AudioSettings, OutputDirectory);
+        UpdatePreviewSettingsOnManager();
+        CaptureManager->SetAudioSubmix(SubmixToCapture);
+    }
+
+    BindDelegates();
+}
+
+void UPanoramaCaptureComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    StopCapture();
+
+    if (CaptureManager.IsValid())
+    {
+        CaptureManager->Shutdown();
+        CaptureManager.Reset();
+    }
+
+    UnbindDelegates();
+    DestroyCaptureRig();
+    Super::EndPlay(EndPlayReason);
+}
+
+void UPanoramaCaptureComponent::OnRegister()
+{
+    Super::OnRegister();
+    CreateCaptureRig();
+    AllocateRenderTargets();
+    UpdatePreviewMaterial();
+}
+
+void UPanoramaCaptureComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (CaptureManager.IsValid())
+    {
+        CaptureManager->Tick_GameThread(DeltaTime);
+    }
+}
+
+void UPanoramaCaptureComponent::StartCapture()
+{
+    if (!CaptureManager.IsValid())
+    {
+        CaptureManager = MakeShared<FPanoramaCaptureManager>();
+        CaptureManager->Initialize(this, VideoSettings, AudioSettings, OutputDirectory);
+        CaptureManager->SetAudioSubmix(SubmixToCapture);
+    }
+
+    UpdatePreviewSettingsOnManager();
+    CaptureManager->StartCapture();
+}
+
+void UPanoramaCaptureComponent::StopCapture()
+{
+    if (CaptureManager.IsValid())
+    {
+        CaptureManager->StopCapture();
+    }
+}
+
+bool UPanoramaCaptureComponent::IsCapturing() const
+{
+    return CachedStatus.bIsCapturing;
+}
+
+void UPanoramaCaptureComponent::SetPreviewEnabled(bool bEnabled)
+{
+    bPreviewRequested = bEnabled;
+    if (PreviewMeshComponent)
+    {
+        PreviewMeshComponent->SetVisibility(bPreviewRequested);
+    }
+    UpdatePreviewSettingsOnManager();
+}
+
+FPanoramicCaptureStatus UPanoramaCaptureComponent::GetCaptureStatus() const
+{
+    return CachedStatus;
+}
+
+int32 UPanoramaCaptureComponent::GetRingBufferCapacity() const
+{
+    return CaptureManager.IsValid() ? CaptureManager->GetRingBufferCapacity() : 0;
+}
+
+int32 UPanoramaCaptureComponent::GetRingBufferOccupancy() const
+{
+    return CaptureManager.IsValid() ? CaptureManager->GetRingBufferOccupancy() : 0;
+}
+
+void UPanoramaCaptureComponent::ReinitializeRig()
+{
+    DestroyCaptureRig();
+    CreateCaptureRig();
+    AllocateRenderTargets();
+    UpdatePreviewMaterial();
+    if (CaptureManager.IsValid())
+    {
+        UpdatePreviewSettingsOnManager();
+        CaptureManager->SetAudioSubmix(SubmixToCapture);
+    }
+}
+
+void UPanoramaCaptureComponent::CreateCaptureRig()
+{
+    DestroyCaptureRig();
+
+    if (AActor* Owner = GetOwner())
+    {
+        LeftEyeFaceTargets.Reset();
+        const int32 FaceResolution = FMath::Max(256, VideoSettings.Resolution.X / 4);
+        for (const FVector& Direction : PanoramaCapture::Directions)
+        {
+            USceneCaptureComponent2D* Capture = NewObject<USceneCaptureComponent2D>(Owner, USceneCaptureComponent2D::StaticClass(), NAME_None, RF_Transactional);
+            Capture->AttachToComponent(this, FAttachmentTransformRules::SnapToTargetIncludingScale);
+            Capture->FOVAngle = 90.f;
+            Capture->ProjectionType = ECameraProjectionMode::Perspective;
+            Capture->bCaptureEveryFrame = false;
+            Capture->bCaptureOnMovement = false;
+            Capture->CaptureSource = ESceneCaptureSource::SCS_FinalColorHDR;
+            Capture->RegisterComponent();
+            Capture->SetRelativeRotation(PanoramaCapture::DirectionToRotation(Direction));
+            UTextureRenderTarget2D* FaceRenderTarget = NewObject<UTextureRenderTarget2D>(this);
+            FaceRenderTarget->RenderTargetFormat = RTF_RGBA16f;
+            FaceRenderTarget->InitAutoFormat(FaceResolution, FaceResolution);
+            FaceRenderTarget->UpdateResourceImmediate(true);
+            Capture->TextureTarget = FaceRenderTarget;
+            LeftEyeCaptures.Add(Capture);
+            LeftEyeFaceTargets.Add(FaceRenderTarget);
+        }
+
+        if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+        {
+            RightEyeFaceTargets.Reset();
+            for (const FVector& Direction : PanoramaCapture::Directions)
+            {
+                USceneCaptureComponent2D* Capture = NewObject<USceneCaptureComponent2D>(Owner, USceneCaptureComponent2D::StaticClass(), NAME_None, RF_Transactional);
+                Capture->AttachToComponent(this, FAttachmentTransformRules::SnapToTargetIncludingScale);
+                Capture->FOVAngle = 90.f;
+                Capture->ProjectionType = ECameraProjectionMode::Perspective;
+                Capture->bCaptureEveryFrame = false;
+                Capture->bCaptureOnMovement = false;
+                Capture->CaptureSource = ESceneCaptureSource::SCS_FinalColorHDR;
+                Capture->RegisterComponent();
+                Capture->SetRelativeRotation(PanoramaCapture::DirectionToRotation(Direction));
+                UTextureRenderTarget2D* FaceRenderTarget = NewObject<UTextureRenderTarget2D>(this);
+                FaceRenderTarget->RenderTargetFormat = RTF_RGBA16f;
+                FaceRenderTarget->InitAutoFormat(FaceResolution, FaceResolution);
+                FaceRenderTarget->UpdateResourceImmediate(true);
+                Capture->TextureTarget = FaceRenderTarget;
+                RightEyeCaptures.Add(Capture);
+                RightEyeFaceTargets.Add(FaceRenderTarget);
+            }
+        }
+
+        if (!PreviewMeshComponent)
+        {
+            PreviewMeshComponent = NewObject<UStaticMeshComponent>(Owner, PanoramaCapture::PreviewMeshName);
+            PreviewMeshComponent->AttachToComponent(this, FAttachmentTransformRules::KeepRelativeTransform);
+            PreviewMeshComponent->RegisterComponent();
+            if (UStaticMesh* PlaneMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Plane.Plane")))
+            {
+                PreviewMeshComponent->SetStaticMesh(PlaneMesh);
+                PreviewMeshComponent->SetRelativeScale3D(FVector(2.0f, 2.0f, 2.0f));
+            }
+        }
+    }
+}
+
+void UPanoramaCaptureComponent::DestroyCaptureRig()
+{
+    for (USceneCaptureComponent2D* Capture : LeftEyeCaptures)
+    {
+        if (Capture)
+        {
+            Capture->DestroyComponent();
+        }
+    }
+    for (USceneCaptureComponent2D* Capture : RightEyeCaptures)
+    {
+        if (Capture)
+        {
+            Capture->DestroyComponent();
+        }
+    }
+    LeftEyeCaptures.Empty();
+    LeftEyeFaceTargets.Empty();
+    RightEyeCaptures.Empty();
+    RightEyeFaceTargets.Empty();
+
+    if (PreviewMeshComponent)
+    {
+        PreviewMeshComponent->DestroyComponent();
+        PreviewMeshComponent = nullptr;
+    }
+
+    if (PreviewEquirectTarget)
+    {
+        PreviewEquirectTarget->ConditionalBeginDestroy();
+        PreviewEquirectTarget = nullptr;
+    }
+}
+
+void UPanoramaCaptureComponent::AllocateRenderTargets()
+{
+    if (!MonoEquirectTarget)
+    {
+        MonoEquirectTarget = NewObject<UTextureRenderTarget2D>(this, TEXT("PanoramaMonoEquirect"));
+    }
+
+    MonoEquirectTarget->RenderTargetFormat = RTF_RGBA16f;
+    MonoEquirectTarget->bAutoGenerateMips = false;
+    MonoEquirectTarget->OverrideFormat = PF_FloatRGBA;
+    MonoEquirectTarget->ClearColor = FLinearColor::Transparent;
+    MonoEquirectTarget->InitAutoFormat(VideoSettings.Resolution.X, VideoSettings.Resolution.Y);
+    MonoEquirectTarget->UpdateResourceImmediate(true);
+
+    const FIntPoint PreviewResolution = GetPreviewResolution();
+    if (!PreviewEquirectTarget)
+    {
+        PreviewEquirectTarget = NewObject<UTextureRenderTarget2D>(this, TEXT("PanoramaPreviewEquirect"));
+    }
+
+    PreviewEquirectTarget->RenderTargetFormat = RTF_RGBA16f;
+    PreviewEquirectTarget->bAutoGenerateMips = false;
+    PreviewEquirectTarget->OverrideFormat = PF_FloatRGBA;
+    PreviewEquirectTarget->ClearColor = FLinearColor::Transparent;
+    PreviewEquirectTarget->InitAutoFormat(PreviewResolution.X, PreviewResolution.Y);
+    PreviewEquirectTarget->UpdateResourceImmediate(true);
+
+    if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        if (!RightEquirectTarget)
+        {
+            RightEquirectTarget = NewObject<UTextureRenderTarget2D>(this, TEXT("PanoramaRightEquirect"));
+        }
+
+        RightEquirectTarget->RenderTargetFormat = RTF_RGBA16f;
+        RightEquirectTarget->bAutoGenerateMips = false;
+        RightEquirectTarget->OverrideFormat = PF_FloatRGBA;
+        RightEquirectTarget->ClearColor = FLinearColor::Transparent;
+        RightEquirectTarget->InitAutoFormat(VideoSettings.Resolution.X, VideoSettings.Resolution.Y);
+        RightEquirectTarget->UpdateResourceImmediate(true);
+    }
+    else if (RightEquirectTarget)
+    {
+        RightEquirectTarget->ConditionalBeginDestroy();
+        RightEquirectTarget = nullptr;
+    }
+}
+
+void UPanoramaCaptureComponent::UpdatePreviewMaterial()
+{
+    if (!PreviewMeshComponent)
+    {
+        return;
+    }
+
+    if (PreviewMaterialTemplate)
+    {
+        PreviewMID = UMaterialInstanceDynamic::Create(PreviewMaterialTemplate, this);
+        PreviewMeshComponent->SetMaterial(0, PreviewMID);
+    }
+
+    if (PreviewMID)
+    {
+        PreviewMID->SetTextureParameterValue(TEXT("PanoramaTexture"), PreviewEquirectTarget ? PreviewEquirectTarget : MonoEquirectTarget);
+    }
+
+    PreviewMeshComponent->SetVisibility(bPreviewRequested);
+}
+
+TArray<USceneCaptureComponent2D*> UPanoramaCaptureComponent::GetActiveCaptureComponents() const
+{
+    TArray<USceneCaptureComponent2D*> Result = LeftEyeCaptures;
+    if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        Result.Append(RightEyeCaptures);
+    }
+    return Result;
+}
+
+void UPanoramaCaptureComponent::BindDelegates()
+{
+    if (!CaptureManager.IsValid())
+    {
+        return;
+    }
+
+    CaptureManager->OnCaptureStatusUpdated.BindUObject(this, &UPanoramaCaptureComponent::HandleStatusUpdated);
+}
+
+void UPanoramaCaptureComponent::UnbindDelegates()
+{
+    if (CaptureManager.IsValid())
+    {
+        CaptureManager->OnCaptureStatusUpdated.Unbind();
+    }
+}
+
+void UPanoramaCaptureComponent::HandleStatusUpdated(const FPanoramicCaptureStatus& Status)
+{
+    CachedStatus = Status;
+}
+
+void UPanoramaCaptureComponent::UpdatePreviewSettingsOnManager()
+{
+    if (!CaptureManager.IsValid())
+    {
+        return;
+    }
+
+    CaptureManager->SetPreviewTargets_GameThread(MonoEquirectTarget, RightEquirectTarget, PreviewEquirectTarget, GetPreviewFrameInterval(), bPreviewRequested);
+}
+
+FIntPoint UPanoramaCaptureComponent::GetPreviewResolution() const
+{
+    const float Scale = FMath::Clamp(PreviewResolutionScale, 0.1f, 1.0f);
+    const int32 Width = FMath::Max(8, FMath::RoundToInt(static_cast<float>(VideoSettings.Resolution.X) * Scale));
+    const int32 Height = FMath::Max(4, FMath::RoundToInt(static_cast<float>(VideoSettings.Resolution.Y) * Scale));
+    return FIntPoint(Width, Height);
+}
+
+float UPanoramaCaptureComponent::GetPreviewFrameInterval() const
+{
+    const float ClampedFPS = FMath::Clamp(PreviewMaxFPS, 5.0f, 120.0f);
+    return (ClampedFPS > 0.f) ? (1.0f / ClampedFPS) : 0.f;
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureFFmpeg.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureFFmpeg.cpp
@@ -1,0 +1,423 @@
+#include "PanoramaCaptureFFmpeg.h"
+#include "PanoramaCaptureFrame.h"
+#include "PanoramaCaptureLog.h"
+#include "Misc/Paths.h"
+#include "HAL/FileManager.h"
+#include "Interfaces/IPluginManager.h"
+#include "HAL/PlatformProcess.h"
+
+namespace
+{
+    const TCHAR* GetFFmpegPixelFormat(EPanoramaColorFormat Format)
+    {
+        switch (Format)
+        {
+        case EPanoramaColorFormat::NV12:
+            return TEXT("nv12");
+        case EPanoramaColorFormat::P010:
+            return TEXT("p010le");
+        case EPanoramaColorFormat::BGRA8:
+            return TEXT("bgra");
+        default:
+            break;
+        }
+        return TEXT("nv12");
+    }
+}
+
+FPanoramaFFmpegMuxer::FPanoramaFFmpegMuxer()
+    : bInitialized(false)
+    , bHasFFmpegExecutable(false)
+    , CapturedFrameCount(0)
+    , CachedAudioDurationSeconds(0.0)
+    , NVENCResolution(FIntPoint::ZeroValue)
+    , NVENCFrameCount(0)
+    , bHasNVENCSource(false)
+    , bNVENCIsHEVC(false)
+    , bNVENCStereo(false)
+    , bNVENCIsCompressedStream(false)
+{
+}
+
+FPanoramaFFmpegMuxer::~FPanoramaFFmpegMuxer()
+{
+    Shutdown();
+}
+
+void FPanoramaFFmpegMuxer::Initialize(const FString& OutputDirectory)
+{
+    TargetDirectory = OutputDirectory;
+    IFileManager::Get().MakeDirectory(*TargetDirectory, true);
+    OutputFilePath = FPaths::Combine(TargetDirectory, TEXT("PanoramaCapture.mp4"));
+    FramesDirectory = FPaths::Combine(TargetDirectory, TEXT("Frames"));
+    FrameFilePattern = FPaths::Combine(FramesDirectory, TEXT("Frame_%06d.png"));
+    CapturedFrameTimestamps.Reset();
+    CapturedFrameCount = 0;
+    CachedAudioDurationSeconds = 0.0;
+    NVENCRawVideoPath.Reset();
+    NVENCResolution = FIntPoint::ZeroValue;
+    NVENCFrameCount = 0;
+    bHasNVENCSource = false;
+    bNVENCIsHEVC = false;
+    bNVENCStereo = false;
+    bNVENCIsCompressedStream = false;
+
+    if (TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("PanoramaCapture")))
+    {
+        const FString ThirdPartyDir = FPaths::Combine(Plugin->GetBaseDir(), TEXT("ThirdParty/Win64"));
+        const FString Candidate = FPaths::Combine(ThirdPartyDir, TEXT("ffmpeg.exe"));
+        bHasFFmpegExecutable = FPaths::FileExists(Candidate);
+        if (bHasFFmpegExecutable)
+        {
+            FFmpegExecutablePath = Candidate;
+        }
+    }
+
+    bInitialized = true;
+
+    UE_LOG(LogPanoramaCapture, Log, TEXT("Muxer initialized output %s"), *OutputFilePath);
+}
+
+void FPanoramaFFmpegMuxer::Shutdown()
+{
+    bInitialized = false;
+    bHasFFmpegExecutable = false;
+    OutputFilePath.Reset();
+    AudioFilePath.Reset();
+    CapturedFrameTimestamps.Reset();
+    CapturedFrameCount = 0;
+    CachedAudioDurationSeconds = 0.0;
+    NVENCRawVideoPath.Reset();
+    NVENCResolution = FIntPoint::ZeroValue;
+    NVENCFrameCount = 0;
+    bHasNVENCSource = false;
+}
+
+void FPanoramaFFmpegMuxer::Configure(const FPanoramicVideoSettings& VideoSettings, const FPanoramicAudioSettings& AudioSettings)
+{
+    CachedVideoSettings = VideoSettings;
+    CachedAudioSettings = AudioSettings;
+    CapturedFrameTimestamps.Reset();
+    CapturedFrameCount = 0;
+    CachedAudioDurationSeconds = 0.0;
+    NVENCResolution = VideoSettings.Resolution;
+    NVENCFrameCount = 0;
+    bHasNVENCSource = false;
+    bNVENCIsHEVC = VideoSettings.bUseHEVC;
+    bNVENCStereo = VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo;
+    bNVENCIsCompressedStream = false;
+
+    const bool bPreferMKV = CachedVideoSettings.bUseHEVC || CachedVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo;
+    const FString ContainerName = bPreferMKV ? TEXT("PanoramaCapture.mkv") : TEXT("PanoramaCapture.mp4");
+    OutputFilePath = FPaths::Combine(TargetDirectory, ContainerName);
+}
+
+void FPanoramaFFmpegMuxer::AddVideoFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+    if (!bInitialized || !Frame.IsValid())
+    {
+        return;
+    }
+
+    if (!Frame->DiskFilePath.IsEmpty())
+    {
+        if (!FPaths::FileExists(Frame->DiskFilePath))
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("PNG frame missing on disk: %s"), *Frame->DiskFilePath);
+            return;
+        }
+
+        CapturedFrameTimestamps.Add(Frame->TimestampSeconds);
+        ++CapturedFrameCount;
+    }
+    else if (Frame->EncodedVideo.Num() > 0)
+    {
+        CapturedFrameTimestamps.Add(Frame->TimestampSeconds);
+        ++CapturedFrameCount;
+        Frame->EncodedVideo.Reset();
+    }
+}
+
+void FPanoramaFFmpegMuxer::AddAudioSamples(const FPanoramaAudioPacket& Packet)
+{
+    if (!bInitialized || Packet.PCMData.Num() == 0)
+    {
+        return;
+    }
+
+    CachedAudioDurationSeconds = FMath::Max(CachedAudioDurationSeconds, Packet.TimestampSeconds + Packet.GetDurationSeconds());
+}
+
+void FPanoramaFFmpegMuxer::SetAudioSource(const FString& FilePath, double DurationSeconds)
+{
+    AudioFilePath = FilePath;
+    CachedAudioDurationSeconds = DurationSeconds;
+}
+
+void FPanoramaFFmpegMuxer::SetNVENCVideoSource(const FString& RawFilePath, const FIntPoint& Resolution, int64 FrameCount, bool bIsHEVC, bool bStereo, bool bIsEncodedStream)
+{
+    NVENCRawVideoPath = RawFilePath;
+    NVENCResolution = Resolution;
+    NVENCFrameCount = FrameCount;
+    bNVENCIsHEVC = bIsHEVC;
+    bNVENCStereo = bStereo;
+    bNVENCIsCompressedStream = bIsEncodedStream;
+    bHasNVENCSource = !NVENCRawVideoPath.IsEmpty() && FPaths::FileExists(NVENCRawVideoPath);
+}
+
+void FPanoramaFFmpegMuxer::FinalizeContainer()
+{
+    if (!bInitialized)
+    {
+        return;
+    }
+
+    if (CachedVideoSettings.OutputFormat == EPanoramaOutputFormat::PNGSequence)
+    {
+        FinalizePNGSequence();
+    }
+    else
+    {
+        FinalizeNVENCStream();
+    }
+}
+
+void FPanoramaFFmpegMuxer::FinalizePNGSequence()
+{
+    if (CapturedFrameCount == 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("No frames were captured - skipping ffmpeg invocation"));
+        return;
+    }
+
+    const double FrameRate = ComputeFrameRate();
+    FString CommandLine = FString::Printf(TEXT("-y -framerate %.6f -i \"%s\""), FrameRate, *FrameFilePattern);
+
+    if (!AudioFilePath.IsEmpty() && FPaths::FileExists(AudioFilePath))
+    {
+        CommandLine += FString::Printf(TEXT(" -i \"%s\" -c:a aac -ar %d -ac %d"), *AudioFilePath, CachedAudioSettings.SampleRate, CachedAudioSettings.NumChannels);
+    }
+
+    if (CachedVideoSettings.bUseHEVC)
+    {
+        CommandLine += FString::Printf(TEXT(" -c:v libx265 -x265-params bitrate=%d"), CachedVideoSettings.TargetBitrateMbps * 1000);
+    }
+    else
+    {
+        CommandLine += FString::Printf(TEXT(" -c:v libx264 -b:v %dk"), CachedVideoSettings.TargetBitrateMbps * 1000);
+    }
+
+    CommandLine += FString::Printf(TEXT(" -g %d"), CachedVideoSettings.GOPLength);
+    CommandLine += FString::Printf(TEXT(" -bf %d"), CachedVideoSettings.NumBFrames);
+    CommandLine += TEXT(" -pix_fmt yuv420p");
+
+    if (CachedVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        const bool bSideBySide = CachedVideoSettings.StereoLayout == EPanoramaStereoLayout::SideBySide;
+        if (bSideBySide)
+        {
+            CommandLine += TEXT(" -metadata:s:v:0 stereo=left-right -metadata:s:v:0 stereomode=left_right");
+        }
+        else
+        {
+            CommandLine += TEXT(" -metadata:s:v:0 stereo=top-bottom -metadata:s:v:0 stereomode=top_bottom");
+        }
+    }
+    else
+    {
+        CommandLine += TEXT(" -metadata:s:v:0 stereo=mono");
+    }
+
+    CommandLine += TEXT(" -metadata:s:v:0 projection=equirectangular");
+    if (CachedVideoSettings.Gamma == EPanoramaGamma::Linear)
+    {
+        CommandLine += TEXT(" -color_primaries bt2020 -colorspace bt2020nc -color_trc smpte2084");
+    }
+    else
+    {
+        CommandLine += TEXT(" -color_primaries bt709 -colorspace bt709 -color_trc bt709");
+    }
+
+    CommandLine += TEXT(" -color_range tv");
+
+    const bool bIsMP4 = OutputFilePath.EndsWith(TEXT(".mp4"));
+    if (bIsMP4)
+    {
+        CommandLine += TEXT(" -movflags +faststart");
+    }
+
+    CommandLine += FString::Printf(TEXT(" \"%s\""), *OutputFilePath);
+
+    if (!InvokeFFmpeg(CommandLine))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to run ffmpeg. Command line: %s"), *CommandLine);
+    }
+    else
+    {
+        UE_LOG(LogPanoramaCapture, Log, TEXT("FFmpeg muxing complete -> %s"), *OutputFilePath);
+        CleanupPNGFrames();
+    }
+}
+
+void FPanoramaFFmpegMuxer::FinalizeNVENCStream()
+{
+    if (!bHasNVENCSource)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC finalize requested without a valid raw video source."));
+        return;
+    }
+
+    if (!FPaths::FileExists(NVENCRawVideoPath))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC raw file missing: %s"), *NVENCRawVideoPath);
+        return;
+    }
+
+    if (NVENCResolution.X <= 0 || NVENCResolution.Y <= 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Invalid NVENC resolution %dx%d"), NVENCResolution.X, NVENCResolution.Y);
+        return;
+    }
+
+    if (CapturedFrameCount == 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("No NVENC frames were captured - skipping ffmpeg invocation"));
+        return;
+    }
+
+    const double FrameRate = ComputeFrameRate();
+    FString CommandLine;
+
+    if (bNVENCIsCompressedStream)
+    {
+        const TCHAR* Demuxer = bNVENCIsHEVC ? TEXT("hevc") : TEXT("h264");
+        CommandLine = FString::Printf(TEXT("-y -f %s -i \"%s\""), Demuxer, *NVENCRawVideoPath);
+        if (!AudioFilePath.IsEmpty() && FPaths::FileExists(AudioFilePath))
+        {
+            CommandLine += FString::Printf(TEXT(" -i \"%s\" -c:a aac -ar %d -ac %d"), *AudioFilePath, CachedAudioSettings.SampleRate, CachedAudioSettings.NumChannels);
+        }
+        CommandLine += TEXT(" -c:v copy");
+        CommandLine += FString::Printf(TEXT(" -r %.6f"), FrameRate);
+    }
+    else
+    {
+        const TCHAR* PixelFormat = GetFFmpegPixelFormat(CachedVideoSettings.ColorFormat);
+        CommandLine = FString::Printf(TEXT("-y -f rawvideo -pix_fmt %s -s %dx%d -r %.6f -i \"%s\""), PixelFormat, NVENCResolution.X, NVENCResolution.Y, FrameRate, *NVENCRawVideoPath);
+
+        if (!AudioFilePath.IsEmpty() && FPaths::FileExists(AudioFilePath))
+        {
+            CommandLine += FString::Printf(TEXT(" -i \"%s\" -c:a aac -ar %d -ac %d"), *AudioFilePath, CachedAudioSettings.SampleRate, CachedAudioSettings.NumChannels);
+        }
+
+        const TCHAR* VideoCodec = bNVENCIsHEVC ? TEXT("hevc_nvenc") : TEXT("h264_nvenc");
+        CommandLine += FString::Printf(TEXT(" -c:v %s"), VideoCodec);
+        CommandLine += FString::Printf(TEXT(" -b:v %dk"), CachedVideoSettings.TargetBitrateMbps * 1000);
+        CommandLine += FString::Printf(TEXT(" -g %d"), CachedVideoSettings.GOPLength);
+        CommandLine += FString::Printf(TEXT(" -bf %d"), CachedVideoSettings.NumBFrames);
+    }
+
+    if (bNVENCStereo)
+    {
+        const bool bSideBySide = CachedVideoSettings.StereoLayout == EPanoramaStereoLayout::SideBySide;
+        if (bSideBySide)
+        {
+            CommandLine += TEXT(" -metadata:s:v:0 stereo=left-right -metadata:s:v:0 stereomode=left_right");
+        }
+        else
+        {
+            CommandLine += TEXT(" -metadata:s:v:0 stereo=top-bottom -metadata:s:v:0 stereomode=top_bottom");
+        }
+    }
+    else
+    {
+        CommandLine += TEXT(" -metadata:s:v:0 stereo=mono");
+    }
+
+    CommandLine += TEXT(" -metadata:s:v:0 projection=equirectangular");
+    if (CachedVideoSettings.Gamma == EPanoramaGamma::Linear)
+    {
+        CommandLine += TEXT(" -color_primaries bt2020 -colorspace bt2020nc -color_trc smpte2084");
+    }
+    else
+    {
+        CommandLine += TEXT(" -color_primaries bt709 -colorspace bt709 -color_trc bt709");
+    }
+
+    CommandLine += TEXT(" -color_range tv");
+
+    const bool bIsMP4 = OutputFilePath.EndsWith(TEXT(".mp4"));
+    if (bIsMP4)
+    {
+        CommandLine += TEXT(" -movflags +faststart");
+    }
+
+    CommandLine += FString::Printf(TEXT(" \"%s\""), *OutputFilePath);
+
+    if (!InvokeFFmpeg(CommandLine))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC ffmpeg invocation failed. Command line: %s"), *CommandLine);
+    }
+    else
+    {
+        UE_LOG(LogPanoramaCapture, Log, TEXT("NVENC ffmpeg muxing complete -> %s"), *OutputFilePath);
+        IFileManager::Get().Delete(*NVENCRawVideoPath);
+    }
+}
+
+void FPanoramaFFmpegMuxer::CleanupPNGFrames()
+{
+    if (FramesDirectory.IsEmpty())
+    {
+        return;
+    }
+
+    IFileManager::Get().DeleteDirectory(*FramesDirectory, false, true);
+}
+
+double FPanoramaFFmpegMuxer::ComputeFrameRate() const
+{
+    if (CapturedFrameTimestamps.Num() <= 1)
+    {
+        return 30.0;
+    }
+
+    const double Duration = CapturedFrameTimestamps.Last() - CapturedFrameTimestamps[0];
+    if (Duration <= KINDA_SMALL_NUMBER)
+    {
+        return 30.0;
+    }
+
+    const double Frames = static_cast<double>(CapturedFrameTimestamps.Num() - 1);
+    return FMath::Clamp(Frames / Duration, 1.0, 120.0);
+}
+
+bool FPanoramaFFmpegMuxer::InvokeFFmpeg(const FString& CommandLine) const
+{
+    if (FFmpegExecutablePath.IsEmpty() || !FPaths::FileExists(FFmpegExecutablePath))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("ffmpeg executable not found at %s"), *FFmpegExecutablePath);
+        return false;
+    }
+
+    UE_LOG(LogPanoramaCapture, Log, TEXT("Invoking ffmpeg %s %s"), *FFmpegExecutablePath, *CommandLine);
+
+    FProcHandle ProcHandle = FPlatformProcess::CreateProc(*FFmpegExecutablePath, *CommandLine, true, false, false, nullptr, 0, nullptr, nullptr);
+    if (!ProcHandle.IsValid())
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to launch ffmpeg process"));
+        return false;
+    }
+
+    FPlatformProcess::WaitForProc(ProcHandle);
+    int32 ReturnCode = 0;
+    FPlatformProcess::GetProcReturnCode(ProcHandle, &ReturnCode);
+    FPlatformProcess::CloseProc(ProcHandle);
+
+    if (ReturnCode != 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("ffmpeg exited with code %d"), ReturnCode);
+        return false;
+    }
+
+    return true;
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureFFmpeg.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureFFmpeg.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PanoramaCaptureTypes.h"
+
+struct FPanoramaFrame;
+
+/** Simple wrapper for ffmpeg muxing of audio/video outputs. */
+class FPanoramaFFmpegMuxer
+{
+public:
+    FPanoramaFFmpegMuxer();
+    ~FPanoramaFFmpegMuxer();
+
+    void Initialize(const FString& OutputDirectory);
+    void Shutdown();
+
+    void Configure(const FPanoramicVideoSettings& VideoSettings, const FPanoramicAudioSettings& AudioSettings);
+    void AddVideoFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+    void AddAudioSamples(const FPanoramaAudioPacket& Packet);
+    void SetAudioSource(const FString& FilePath, double DurationSeconds);
+    void SetNVENCVideoSource(const FString& RawFilePath, const FIntPoint& Resolution, int64 FrameCount, bool bIsHEVC, bool bStereo, bool bIsEncodedStream);
+
+    void FinalizeContainer();
+
+    bool IsFFmpegAvailable() const { return bHasFFmpegExecutable; }
+
+private:
+    void FinalizePNGSequence();
+    void FinalizeNVENCStream();
+    void CleanupPNGFrames();
+    double ComputeFrameRate() const;
+    bool InvokeFFmpeg(const FString& CommandLine) const;
+
+    FString TargetDirectory;
+    FString OutputFilePath;
+    FString FramesDirectory;
+    FString FrameFilePattern;
+    FString FFmpegExecutablePath;
+    FString AudioFilePath;
+    FString NVENCRawVideoPath;
+    bool bInitialized;
+    bool bHasFFmpegExecutable;
+    FPanoramicVideoSettings CachedVideoSettings;
+    FPanoramicAudioSettings CachedAudioSettings;
+    TArray<double> CapturedFrameTimestamps;
+    int32 CapturedFrameCount;
+    double CachedAudioDurationSeconds;
+    FIntPoint NVENCResolution;
+    int64 NVENCFrameCount;
+    bool bHasNVENCSource;
+    bool bNVENCIsHEVC;
+    bool bNVENCStereo;
+    bool bNVENCIsCompressedStream;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureManager.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureManager.cpp
@@ -1,0 +1,869 @@
+#include "PanoramaCaptureManager.h"
+#include "PanoramaCaptureComponent.h"
+#include "PanoramaCaptureRenderer.h"
+#include "PanoramaCaptureAudio.h"
+#include "PanoramaCaptureFFmpeg.h"
+#include "PanoramaCaptureNVENC.h"
+#include "PanoramaCaptureFrame.h"
+#include "PanoramaCaptureLog.h"
+#include "Async/Async.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformFilemanager.h"
+#include "HAL/Runnable.h"
+#include "HAL/RunnableThread.h"
+#include "HAL/Event.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"
+#include "HAL/ThreadSafeCounter.h"
+#include "Modules/ModuleManager.h"
+#include "IImageWrapper.h"
+#include "IImageWrapperModule.h"
+
+namespace
+{
+    static constexpr TCHAR const* GFrameSubdirectory = TEXT("Frames");
+}
+
+class FPanoramaCaptureManager::FFrameProcessor : public FRunnable
+{
+public:
+    explicit FFrameProcessor(FPanoramaCaptureManager& InOwner)
+        : Owner(InOwner)
+        , WorkEvent(FPlatformProcess::GetSynchEventFromPool(false))
+    {
+    }
+
+    virtual ~FFrameProcessor()
+    {
+        if (WorkEvent)
+        {
+            FPlatformProcess::ReturnSynchEventToPool(WorkEvent);
+            WorkEvent = nullptr;
+        }
+    }
+
+    virtual uint32 Run() override
+    {
+        while (!StopTaskCounter.GetValue())
+        {
+            WorkEvent->Wait();
+            Owner.ProcessPendingFrames_Worker();
+        }
+        return 0;
+    }
+
+    virtual void Stop() override
+    {
+        StopTaskCounter.Increment();
+        if (WorkEvent)
+        {
+            WorkEvent->Trigger();
+        }
+    }
+
+    void SignalWork()
+    {
+        if (WorkEvent)
+        {
+            WorkEvent->Trigger();
+        }
+    }
+
+private:
+    FPanoramaCaptureManager& Owner;
+    FEvent* WorkEvent;
+    FThreadSafeCounter StopTaskCounter;
+};
+
+FPanoramaCaptureManager::FPanoramaCaptureManager()
+    : bInitialized(false)
+    , bCaptureRequested(false)
+    , bCaptureActive(false)
+    , CaptureStartTimeSeconds(0.0)
+    , FrameCounter(0)
+    , PreviewFrameIntervalSeconds(1.0f / 30.0f)
+    , LastPreviewUpdateSeconds(0.0)
+    , bPreviewEnabled(true)
+    , bHasFallenBack(false)
+{
+    ResetStatus();
+}
+
+FPanoramaCaptureManager::~FPanoramaCaptureManager()
+{
+    Shutdown();
+}
+
+void FPanoramaCaptureManager::Initialize(UPanoramaCaptureComponent* InOwnerComponent, const FPanoramicVideoSettings& VideoSettings, const FPanoramicAudioSettings& AudioSettings, const FString& OutputDirectory)
+{
+    if (bInitialized)
+    {
+        return;
+    }
+
+    CurrentVideoSettings = VideoSettings;
+    CurrentAudioSettings = AudioSettings;
+    TargetOutputDirectory = OutputDirectory.IsEmpty() ? FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("PanoramaCaptures")) : OutputDirectory;
+    OwnerComponent = InOwnerComponent;
+
+    Renderer = MakeUnique<FPanoramaCaptureRenderer>();
+    Renderer->Initialize();
+
+    AudioRecorder = MakeUnique<FPanoramaAudioRecorder>();
+    AudioRecorder->Initialize(CurrentAudioSettings, TargetOutputDirectory, InOwnerComponent ? InOwnerComponent->GetWorld() : nullptr);
+
+    VideoEncoder = MakeUnique<FPanoramaNVENCEncoder>();
+    VideoEncoder->Initialize(CurrentVideoSettings, TargetOutputDirectory);
+
+    Muxer = MakeUnique<FPanoramaFFmpegMuxer>();
+    Muxer->Initialize(TargetOutputDirectory);
+    Muxer->Configure(CurrentVideoSettings, CurrentAudioSettings);
+
+    ResetStatus();
+    bInitialized = true;
+}
+
+void FPanoramaCaptureManager::Shutdown()
+{
+    StopWorkers();
+
+    if (AudioRecorder)
+    {
+        AudioRecorder->Shutdown();
+        AudioRecorder.Reset();
+    }
+
+    if (VideoEncoder)
+    {
+        VideoEncoder->Shutdown();
+        VideoEncoder.Reset();
+    }
+
+    if (Muxer)
+    {
+        Muxer->Shutdown();
+        Muxer.Reset();
+    }
+
+    if (Renderer)
+    {
+        Renderer->Shutdown();
+        Renderer.Reset();
+    }
+
+    FrameQueue.Reset();
+    bInitialized = false;
+}
+
+void FPanoramaCaptureManager::StartCapture()
+{
+    if (!bInitialized)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("StartCapture called before Initialize"));
+        return;
+    }
+
+    if (bCaptureActive)
+    {
+        return;
+    }
+
+    LastWarningMessage.Reset();
+    bHasFallenBack = false;
+    PerformPreflightChecks();
+
+    bCaptureRequested = true;
+    bCaptureActive = true;
+    FrameCounter = 0;
+    PendingLeftFrame.Reset();
+    PendingNVENCLeftFrame.Reset();
+    FrameQueue.Reset();
+    CaptureStartTimeSeconds = FPlatformTime::Seconds();
+    ResetStatus();
+    if (Muxer)
+    {
+        Muxer->Configure(CurrentVideoSettings, CurrentAudioSettings);
+    }
+    StartWorkers();
+    {
+        FScopeLock Lock(&StatusCriticalSection);
+        CachedStatus.bIsCapturing = true;
+        CachedStatus.CurrentCaptureTimeSeconds = 0.f;
+        CachedStatus.bUsingNVENC = CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC;
+        CachedStatus.EffectiveVideoSettings = CurrentVideoSettings;
+    }
+
+    if (AudioRecorder)
+    {
+        AudioRecorder->SetCaptureStartTime(CaptureStartTimeSeconds);
+        AudioRecorder->StartRecording();
+    }
+
+    {
+        FScopeLock Lock(&StatusCriticalSection);
+        CachedStatus.PendingFrameCount = 0;
+        CachedStatus.DroppedFrames = 0;
+    }
+}
+
+void FPanoramaCaptureManager::StopCapture()
+{
+    if (!bCaptureActive)
+    {
+        return;
+    }
+
+    bCaptureRequested = false;
+    bCaptureActive = false;
+
+    if (AudioRecorder)
+    {
+        AudioRecorder->StopRecording();
+        if (Muxer)
+        {
+            TArray<FPanoramaAudioPacket> FinalPackets;
+            AudioRecorder->ConsumeAudioPackets(FinalPackets);
+            for (const FPanoramaAudioPacket& Packet : FinalPackets)
+            {
+                if (Packet.PCMData.Num() > 0)
+                {
+                    Muxer->AddAudioSamples(Packet);
+                    UpdateStatusAfterAudioPacket(Packet);
+                }
+            }
+        }
+        AudioRecorder->FinalizeWaveFile();
+        const FString AudioPath = AudioRecorder->GetWaveFilePath();
+        if (Muxer && !AudioPath.IsEmpty() && FPaths::FileExists(AudioPath))
+        {
+            Muxer->SetAudioSource(AudioPath, AudioRecorder->GetRecordingDurationSeconds());
+        }
+    }
+
+    StopWorkers();
+
+    PendingLeftFrame.Reset();
+    PendingNVENCLeftFrame.Reset();
+
+    if (VideoEncoder)
+    {
+        VideoEncoder->Flush();
+        if (CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC && Muxer)
+        {
+            const bool bStereo = CurrentVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo;
+            const bool bEncodedStream = VideoEncoder->SupportsZeroCopy();
+            Muxer->SetNVENCVideoSource(VideoEncoder->GetRawVideoPath(), VideoEncoder->GetEncodedResolution(), VideoEncoder->GetEncodedFrameCount(), VideoEncoder->IsUsingHEVC(), bStereo, bEncodedStream);
+        }
+    }
+
+    if (Muxer)
+    {
+        Muxer->FinalizeContainer();
+    }
+
+    {
+        FScopeLock Lock(&StatusCriticalSection);
+        CachedStatus.bIsCapturing = false;
+    }
+    NotifyStatus_GameThread();
+}
+
+void FPanoramaCaptureManager::EnqueueFrame_RenderThread(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+    if (!Frame.IsValid())
+    {
+        return;
+    }
+
+    if (!FrameQueue.Enqueue(Frame))
+    {
+        FScopeLock Lock(&StatusCriticalSection);
+        CachedStatus.DroppedFrames++;
+    }
+    else if (FrameProcessor.IsValid())
+    {
+        FrameProcessor->SignalWork();
+    }
+}
+
+FPanoramicCaptureStatus FPanoramaCaptureManager::GetStatus() const
+{
+    FScopeLock Lock(&StatusCriticalSection);
+    return CachedStatus;
+}
+
+int32 FPanoramaCaptureManager::GetRingBufferCapacity() const
+{
+    return FrameQueue.GetCapacity();
+}
+
+int32 FPanoramaCaptureManager::GetRingBufferOccupancy() const
+{
+    return FrameQueue.Num();
+}
+
+void FPanoramaCaptureManager::Tick_GameThread(float DeltaTime)
+{
+    if (!bCaptureActive)
+    {
+        return;
+    }
+
+    {
+        FScopeLock Lock(&StatusCriticalSection);
+        CachedStatus.CurrentCaptureTimeSeconds = static_cast<float>(FPlatformTime::Seconds() - CaptureStartTimeSeconds);
+    }
+
+    if (AudioRecorder)
+    {
+        AudioRecorder->Tick(DeltaTime);
+        TArray<FPanoramaAudioPacket> CapturedPackets;
+        AudioRecorder->ConsumeAudioPackets(CapturedPackets);
+        if (Muxer)
+        {
+            for (const FPanoramaAudioPacket& Packet : CapturedPackets)
+            {
+                if (Packet.PCMData.Num() > 0)
+                {
+                    Muxer->AddAudioSamples(Packet);
+                    UpdateStatusAfterAudioPacket(Packet);
+                }
+            }
+        }
+    }
+
+    if (Renderer && OwnerComponent.IsValid())
+    {
+        const bool bZeroCopy = VideoEncoder && VideoEncoder->SupportsZeroCopy();
+        Renderer->CaptureFrame(OwnerComponent.Get(), CurrentVideoSettings, CaptureStartTimeSeconds, bZeroCopy, [this](const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+        {
+            EnqueueFrame_RenderThread(Frame);
+        });
+    }
+
+    if (!FrameProcessor.IsValid())
+    {
+        ProcessPendingFrames();
+    }
+    NotifyStatus_GameThread();
+
+    {
+        FScopeLock Lock(&StatusCriticalSection);
+        CachedStatus.CurrentCaptureTimeSeconds += DeltaTime;
+    }
+}
+
+void FPanoramaCaptureManager::SetPreviewTargets_GameThread(UTextureRenderTarget2D* MonoTarget, UTextureRenderTarget2D* RightTarget, UTextureRenderTarget2D* PreviewTarget, float InPreviewInterval, bool bInPreviewEnabled)
+{
+    MonoTargetWeak = MonoTarget;
+    StereoTargetWeak = RightTarget;
+    PreviewTargetWeak = PreviewTarget;
+    PreviewFrameIntervalSeconds = (InPreviewInterval > 0.f) ? InPreviewInterval : 0.f;
+    bPreviewEnabled = bInPreviewEnabled;
+    LastPreviewUpdateSeconds = 0.0;
+
+    if (Renderer)
+    {
+        Renderer->SetOutputTargets(MonoTarget, RightTarget, PreviewTarget, PreviewFrameIntervalSeconds, bPreviewEnabled);
+    }
+}
+
+void FPanoramaCaptureManager::SetAudioSubmix(USoundSubmix* Submix)
+{
+    if (AudioRecorder)
+    {
+        AudioRecorder->SetSubmixToRecord(Submix);
+    }
+}
+
+void FPanoramaCaptureManager::StartWorkers()
+{
+    if (FrameProcessor.IsValid())
+    {
+        return;
+    }
+
+    FrameProcessor = MakeUnique<FFrameProcessor>(*this);
+    FrameProcessorThread.Reset(FRunnableThread::Create(FrameProcessor.Get(), TEXT("PanoramaFrameProcessor"), 0, TPri_AboveNormal));
+    if (!FrameProcessorThread.IsValid())
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to spawn frame processor thread - falling back to game thread processing"));
+        FrameProcessor.Reset();
+    }
+}
+
+void FPanoramaCaptureManager::StopWorkers()
+{
+    if (!FrameProcessor.IsValid())
+    {
+        return;
+    }
+
+    FrameProcessor->Stop();
+    if (FrameProcessorThread.IsValid())
+    {
+        FrameProcessorThread->WaitForCompletion();
+        FrameProcessorThread.Reset();
+    }
+    FrameProcessor.Reset();
+}
+
+void FPanoramaCaptureManager::ProcessPendingFrames()
+{
+    if (!VideoEncoder || !Muxer)
+    {
+        return;
+    }
+
+    TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> Frame;
+    while ((Frame = FrameQueue.Dequeue()).IsValid())
+    {
+        if (CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::PNGSequence)
+        {
+            HandlePNGFrame(Frame);
+        }
+        else
+        {
+            HandleNVENCFrame(Frame);
+        }
+        {
+            FScopeLock Lock(&StatusCriticalSection);
+            CachedStatus.PendingFrameCount = FrameQueue.Num();
+        }
+    }
+}
+
+void FPanoramaCaptureManager::ProcessPendingFrames_Worker()
+{
+    if (!VideoEncoder || !Muxer)
+    {
+        return;
+    }
+
+    TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> Frame;
+    while ((Frame = FrameQueue.Dequeue()).IsValid())
+    {
+        if (CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::PNGSequence)
+        {
+            HandlePNGFrame(Frame);
+        }
+        else
+        {
+            HandleNVENCFrame(Frame);
+        }
+
+        UpdateStatusAfterVideoFrame(nullptr);
+    }
+}
+
+bool FPanoramaCaptureManager::HandlePNGFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+    if (!Frame.IsValid())
+    {
+        return false;
+    }
+
+    if (CurrentVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo && Frame->EyeIndex == 1)
+    {
+        if (PendingLeftFrame.IsValid())
+        {
+            const bool bResult = HandleStereoPNGPair(PendingLeftFrame, Frame);
+            PendingLeftFrame.Reset();
+            return bResult;
+        }
+        return false;
+    }
+
+    if (CurrentVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        PendingLeftFrame = Frame;
+        return true;
+    }
+
+    const FString FilePath = BuildPNGFilePath(FrameCounter++);
+    const bool bSuccess = SavePNGToDisk(FilePath, Frame->LinearPixels, Frame->Resolution);
+    if (bSuccess)
+    {
+        Frame->DiskFilePath = FilePath;
+        Frame->LinearPixels.Reset();
+        Muxer->AddVideoFrame(Frame);
+        UpdateStatusAfterVideoFrame(Frame);
+    }
+    return bSuccess;
+}
+
+bool FPanoramaCaptureManager::HandleStereoPNGPair(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame)
+{
+    if (!LeftFrame.IsValid() || !RightFrame.IsValid())
+    {
+        return false;
+    }
+
+    const FIntPoint LeftRes = LeftFrame->Resolution;
+    const FIntPoint RightRes = RightFrame->Resolution;
+    if (LeftRes != RightRes || LeftFrame->LinearPixels.Num() == 0 || RightFrame->LinearPixels.Num() == 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Stereo frame mismatch - skipping pair"));
+        return false;
+    }
+
+    const bool bSideBySide = CurrentVideoSettings.StereoLayout == EPanoramaStereoLayout::SideBySide;
+    TArray<FFloat16Color> Combined;
+    FIntPoint CombinedRes;
+    if (bSideBySide)
+    {
+        CombinedRes = FIntPoint(LeftRes.X * 2, LeftRes.Y);
+        Combined.SetNumUninitialized(CombinedRes.X * CombinedRes.Y);
+        for (int32 Row = 0; Row < LeftRes.Y; ++Row)
+        {
+            const int32 LeftRowIndex = Row * LeftRes.X;
+            const int32 RightRowIndex = Row * RightRes.X;
+            FFloat16Color* DestRow = Combined.GetData() + Row * CombinedRes.X;
+            FMemory::Memcpy(DestRow, LeftFrame->LinearPixels.GetData() + LeftRowIndex, sizeof(FFloat16Color) * LeftRes.X);
+            FMemory::Memcpy(DestRow + LeftRes.X, RightFrame->LinearPixels.GetData() + RightRowIndex, sizeof(FFloat16Color) * RightRes.X);
+        }
+    }
+    else
+    {
+        CombinedRes = FIntPoint(LeftRes.X, LeftRes.Y * 2);
+        const int32 TotalPixels = LeftFrame->LinearPixels.Num() + RightFrame->LinearPixels.Num();
+        Combined.Reserve(TotalPixels);
+        Combined.Append(LeftFrame->LinearPixels);
+        Combined.Append(RightFrame->LinearPixels);
+    }
+
+    const FString FilePath = BuildPNGFilePath(FrameCounter++);
+    const bool bSuccess = SavePNGToDisk(FilePath, Combined, CombinedRes);
+    if (bSuccess)
+    {
+        LeftFrame->DiskFilePath = FilePath;
+        LeftFrame->LinearPixels.Reset();
+        LeftFrame->Resolution = CombinedRes;
+        LeftFrame->bIsStereo = true;
+        Muxer->AddVideoFrame(LeftFrame);
+        UpdateStatusAfterVideoFrame(LeftFrame);
+    }
+    RightFrame->LinearPixels.Reset();
+    return bSuccess;
+}
+
+bool FPanoramaCaptureManager::SavePNGToDisk(const FString& Filename, const TArray<FFloat16Color>& Pixels, const FIntPoint& Resolution)
+{
+    if (Pixels.Num() == 0 || Resolution.X <= 0 || Resolution.Y <= 0)
+    {
+        return false;
+    }
+
+    const int32 ExpectedPixels = Resolution.X * Resolution.Y;
+    if (ExpectedPixels != Pixels.Num())
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("PNG save aborted due to mismatched pixel count %d vs expected %d"), Pixels.Num(), ExpectedPixels);
+        return false;
+    }
+
+    IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>(TEXT("ImageWrapper"));
+    TSharedPtr<IImageWrapper> ImageWriter = ImageWrapperModule.CreateImageWrapper(EImageFormat::PNG);
+    if (!ImageWriter.IsValid())
+    {
+        return false;
+    }
+
+    TArray<uint16> RawBuffer;
+    RawBuffer.SetNum(ExpectedPixels * 4);
+
+    for (int32 PixelIndex = 0; PixelIndex < ExpectedPixels; ++PixelIndex)
+    {
+        const FFloat16Color& Source = Pixels[PixelIndex];
+        const int32 BaseIndex = PixelIndex * 4;
+        RawBuffer[BaseIndex + 0] = static_cast<uint16>(FMath::Clamp(Source.R.GetFloat() * 65535.0f, 0.0f, 65535.0f));
+        RawBuffer[BaseIndex + 1] = static_cast<uint16>(FMath::Clamp(Source.G.GetFloat() * 65535.0f, 0.0f, 65535.0f));
+        RawBuffer[BaseIndex + 2] = static_cast<uint16>(FMath::Clamp(Source.B.GetFloat() * 65535.0f, 0.0f, 65535.0f));
+        RawBuffer[BaseIndex + 3] = static_cast<uint16>(FMath::Clamp(Source.A.GetFloat() * 65535.0f, 0.0f, 65535.0f));
+    }
+
+    if (!ImageWriter->SetRaw(RawBuffer.GetData(), RawBuffer.Num() * sizeof(uint16), Resolution.X, Resolution.Y, ERGBFormat::RGBA, 16))
+    {
+        return false;
+    }
+
+    const TArray64<uint8>& Compressed = ImageWriter->GetCompressed(0);
+    if (Compressed.Num() == 0)
+    {
+        return false;
+    }
+
+    const FString Directory = FPaths::GetPath(Filename);
+    IFileManager::Get().MakeDirectory(*Directory, true);
+    return FFileHelper::SaveArrayToFile(Compressed, *Filename);
+}
+
+FString FPanoramaCaptureManager::BuildPNGFilePath(int32 FrameIndex) const
+{
+    const FString FramesDir = FPaths::Combine(TargetOutputDirectory, GFrameSubdirectory);
+    return FPaths::Combine(FramesDir, FString::Printf(TEXT("Frame_%06d.png"), FrameIndex));
+}
+
+void FPanoramaCaptureManager::ProcessPendingAudio()
+{
+    // Audio is handled during Tick_GameThread via ConsumeCapturedAudio.
+}
+
+void FPanoramaCaptureManager::NotifyStatus_GameThread()
+{
+    FScopeLock Lock(&StatusCriticalSection);
+    if (VideoEncoder.IsValid())
+    {
+        CachedStatus.bZeroCopyRequested = VideoEncoder->WasZeroCopyRequested();
+        CachedStatus.bZeroCopyActive = VideoEncoder->SupportsZeroCopy();
+        CachedStatus.ZeroCopyDiagnostic = VideoEncoder->GetZeroCopyDiagnostic();
+    }
+    const int32 Occupancy = FrameQueue.Num();
+    CachedStatus.PendingFrameCount = Occupancy;
+    CachedStatus.DroppedFrames = FrameQueue.GetDroppedCount();
+    const int32 Capacity = FrameQueue.GetCapacity();
+    CachedStatus.RingBufferFill = (Capacity > 0) ? static_cast<float>(Occupancy) / static_cast<float>(Capacity) : 0.f;
+    CachedStatus.bUsingFallback = bHasFallenBack;
+    CachedStatus.LastWarning = LastWarningMessage;
+    if (OnCaptureStatusUpdated.IsBound())
+    {
+        OnCaptureStatusUpdated.Execute(CachedStatus);
+    }
+}
+
+bool FPanoramaCaptureManager::HandleNVENCFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+    if (!Frame.IsValid() || !VideoEncoder || !Muxer)
+    {
+        return false;
+    }
+
+    if (VideoEncoder->SupportsZeroCopy())
+    {
+        if (CurrentVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo && Frame->EyeIndex == 1)
+        {
+            return true;
+        }
+
+        if (!Frame->NVENCTexture.IsValid())
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC zero-copy frame missing GPU texture."));
+            return false;
+        }
+
+        if (VideoEncoder->EncodeFrame(Frame))
+        {
+            Muxer->AddVideoFrame(Frame);
+            UpdateStatusAfterVideoFrame(Frame);
+            return true;
+        }
+
+        return false;
+    }
+
+    if (CurrentVideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        if (Frame->EyeIndex == 0)
+        {
+            PendingNVENCLeftFrame = Frame;
+            return true;
+        }
+
+        if (Frame->EyeIndex == 1 && PendingNVENCLeftFrame.IsValid())
+        {
+            TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> Encoded = HandleStereoNVENCPair(PendingNVENCLeftFrame, Frame);
+            PendingNVENCLeftFrame.Reset();
+            if (Encoded.IsValid())
+            {
+                Muxer->AddVideoFrame(Encoded);
+                UpdateStatusAfterVideoFrame(Encoded);
+                return true;
+            }
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC failed to encode stereo pair."));
+        }
+        return false;
+    }
+
+    if (VideoEncoder->EncodeFrame(Frame))
+    {
+        Muxer->AddVideoFrame(Frame);
+        UpdateStatusAfterVideoFrame(Frame);
+        return true;
+    }
+
+    UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC failed to encode mono frame (eye=%d)."), Frame->EyeIndex);
+
+    return false;
+}
+
+TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> FPanoramaCaptureManager::HandleStereoNVENCPair(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame)
+{
+    if (!VideoEncoder)
+    {
+        return nullptr;
+    }
+
+    return VideoEncoder->EncodeStereoPair(LeftFrame, RightFrame);
+}
+
+void FPanoramaCaptureManager::UpdateStatusAfterVideoFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+    FScopeLock Lock(&StatusCriticalSection);
+    const int32 Occupancy = FrameQueue.Num();
+    CachedStatus.PendingFrameCount = Occupancy;
+    CachedStatus.DroppedFrames = FrameQueue.GetDroppedCount();
+    const int32 Capacity = FrameQueue.GetCapacity();
+    CachedStatus.RingBufferFill = (Capacity > 0) ? static_cast<float>(Occupancy) / static_cast<float>(Capacity) : 0.f;
+    if (Frame.IsValid())
+    {
+        CachedStatus.LastVideoPTS = Frame->TimestampSeconds;
+    }
+}
+
+void FPanoramaCaptureManager::UpdateStatusAfterAudioPacket(const FPanoramaAudioPacket& Packet)
+{
+    if (Packet.PCMData.Num() == 0)
+    {
+        return;
+    }
+
+    const double PacketEnd = Packet.TimestampSeconds + Packet.GetDurationSeconds();
+    FScopeLock Lock(&StatusCriticalSection);
+    CachedStatus.LastAudioPTS = FMath::Max(CachedStatus.LastAudioPTS, PacketEnd);
+}
+
+void FPanoramaCaptureManager::ResetStatus()
+{
+    FScopeLock Lock(&StatusCriticalSection);
+    CachedStatus = FPanoramicCaptureStatus();
+    CachedStatus.bUsingNVENC = CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC;
+    CachedStatus.bUsingFallback = bHasFallenBack;
+    CachedStatus.LastWarning = LastWarningMessage;
+    if (VideoEncoder.IsValid())
+    {
+        CachedStatus.bZeroCopyRequested = VideoEncoder->WasZeroCopyRequested();
+        CachedStatus.bZeroCopyActive = VideoEncoder->SupportsZeroCopy();
+        CachedStatus.ZeroCopyDiagnostic = VideoEncoder->GetZeroCopyDiagnostic();
+    }
+    else
+    {
+        CachedStatus.bZeroCopyRequested = false;
+        CachedStatus.bZeroCopyActive = false;
+        CachedStatus.ZeroCopyDiagnostic.Reset();
+    }
+    CachedStatus.EffectiveVideoSettings = CurrentVideoSettings;
+    const int32 Occupancy = FrameQueue.Num();
+    CachedStatus.PendingFrameCount = Occupancy;
+    CachedStatus.DroppedFrames = FrameQueue.GetDroppedCount();
+    const int32 Capacity = FrameQueue.GetCapacity();
+    CachedStatus.RingBufferFill = (Capacity > 0) ? static_cast<float>(Occupancy) / static_cast<float>(Capacity) : 0.f;
+}
+
+bool FPanoramaCaptureManager::PerformPreflightChecks()
+{
+    bool bAllGood = true;
+
+    if (CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC)
+    {
+        const bool bHardwareReady = VideoEncoder.IsValid() && VideoEncoder->IsInitialized() && VideoEncoder->HasHardware();
+        if (!bHardwareReady)
+        {
+            PushWarningMessage(TEXT("NVENC hardware unavailable - reverting to PNG sequence."));
+            CurrentVideoSettings.OutputFormat = EPanoramaOutputFormat::PNGSequence;
+            bHasFallenBack = true;
+            bAllGood = false;
+        }
+    }
+
+    if (Muxer.IsValid() && !Muxer->IsFFmpegAvailable())
+    {
+        PushWarningMessage(TEXT("ffmpeg executable missing - automatic muxing will be skipped."));
+        bAllGood = false;
+    }
+
+    if (!VerifyDiskCapacity())
+    {
+        bAllGood = false;
+    }
+
+    ApplyFallbackIfNeeded();
+    return bAllGood;
+}
+
+bool FPanoramaCaptureManager::VerifyDiskCapacity()
+{
+    IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+    const uint64 FreeSpace = PlatformFile.GetDiskFreeSpace(*TargetOutputDirectory);
+    if (FreeSpace == 0)
+    {
+        PushWarningMessage(TEXT("Unable to query disk free space; proceeding with caution."));
+        return true;
+    }
+
+    const uint64 Threshold = 2ull * 1024ull * 1024ull * 1024ull; // 2 GB safety margin
+    if (FreeSpace < Threshold)
+    {
+        const double FreeGB = static_cast<double>(FreeSpace) / (1024.0 * 1024.0 * 1024.0);
+        PushWarningMessage(FString::Printf(TEXT("Low disk space (%.2f GB remaining)"), FreeGB));
+        return false;
+    }
+    return true;
+}
+
+void FPanoramaCaptureManager::ApplyFallbackIfNeeded()
+{
+    bool bZeroCopyRequested = false;
+    bool bZeroCopyActive = false;
+    FString ZeroCopyMessage;
+
+    if (VideoEncoder.IsValid())
+    {
+        VideoEncoder->Shutdown();
+        VideoEncoder->Initialize(CurrentVideoSettings, TargetOutputDirectory);
+        bZeroCopyRequested = VideoEncoder->WasZeroCopyRequested();
+        bZeroCopyActive = VideoEncoder->SupportsZeroCopy();
+        ZeroCopyMessage = VideoEncoder->GetZeroCopyDiagnostic();
+        if (bZeroCopyRequested && !bZeroCopyActive && !ZeroCopyMessage.IsEmpty())
+        {
+            PushWarningMessage(ZeroCopyMessage);
+        }
+    }
+
+    if (Muxer.IsValid())
+    {
+        Muxer->Configure(CurrentVideoSettings, CurrentAudioSettings);
+    }
+
+    if (bZeroCopyRequested && !bZeroCopyActive)
+    {
+        bHasFallenBack = true;
+    }
+
+    FScopeLock Lock(&StatusCriticalSection);
+    CachedStatus.bUsingNVENC = CurrentVideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC;
+    CachedStatus.bUsingFallback = bHasFallenBack;
+    CachedStatus.LastWarning = LastWarningMessage;
+    CachedStatus.bZeroCopyRequested = bZeroCopyRequested;
+    CachedStatus.bZeroCopyActive = bZeroCopyActive;
+    CachedStatus.ZeroCopyDiagnostic = ZeroCopyMessage;
+    CachedStatus.EffectiveVideoSettings = CurrentVideoSettings;
+}
+
+void FPanoramaCaptureManager::PushWarningMessage(const FString& Message)
+{
+    if (Message.IsEmpty())
+    {
+        return;
+    }
+
+    if (!LastWarningMessage.IsEmpty())
+    {
+        LastWarningMessage += TEXT("\n");
+    }
+    LastWarningMessage += Message;
+
+    FScopeLock Lock(&StatusCriticalSection);
+    CachedStatus.LastWarning = LastWarningMessage;
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureModule.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureModule.cpp
@@ -1,0 +1,23 @@
+#include "PanoramaCaptureModule.h"
+#include "PanoramaCaptureLog.h"
+#include "Modules/ModuleManager.h"
+#include "Interfaces/IPluginManager.h"
+#include "ShaderCore.h"
+
+IMPLEMENT_MODULE(FPanoramaCaptureModule, PanoramaCapture)
+
+DEFINE_LOG_CATEGORY(LogPanoramaCapture);
+
+void FPanoramaCaptureModule::StartupModule()
+{
+    if (const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("PanoramaCapture")))
+    {
+        FString ShaderDir = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Shaders"));
+        AddShaderSourceDirectoryMapping(TEXT("/PanoramaCapture"), ShaderDir);
+    }
+}
+
+void FPanoramaCaptureModule::ShutdownModule()
+{
+    ResetAllShaderSourceDirectoryMappings();
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureModule.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureModule.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Modules/ModuleInterface.h"
+
+class FPanoramaCaptureModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureNVENC.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureNVENC.cpp
@@ -1,0 +1,1044 @@
+#include "PanoramaCaptureNVENC.h"
+#include "PanoramaCaptureFrame.h"
+#include "PanoramaCaptureLog.h"
+#include "PanoramaCaptureColorConversion.h"
+
+#include "HAL/PlatformFilemanager.h"
+#include "Misc/Paths.h"
+#include "RHI.h"
+
+#if PANORAMA_WITH_NVENC
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <d3d11.h>
+#include <d3d12.h>
+#include "nvEncodeAPI.h"
+#include "Windows/HideWindowsPlatformTypes.h"
+#endif
+
+using namespace PanoramaCapture::Color;
+
+FPanoramaNVENCEncoder::FNVENCAPI::FNVENCAPI()
+    : bLoaded(false)
+{
+    FMemory::Memzero(FunctionList);
+    FunctionList.version = NV_ENCODE_API_FUNCTION_LIST_VER;
+    const NVENCSTATUS Status = NvEncodeAPICreateInstance(&FunctionList);
+    bLoaded = (Status == NV_ENC_SUCCESS);
+    if (!bLoaded)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NvEncodeAPICreateInstance failed with status %d"), static_cast<int32>(Status));
+    }
+}
+#endif
+
+FPanoramaNVENCEncoder::FPanoramaNVENCEncoder()
+    : bInitialized(false)
+    , Bitrate(0)
+    , EncodedFrameCount(0)
+    , EncodedResolution(FIntPoint::ZeroValue)
+    , LastVideoPTS(0.0)
+{
+#if PANORAMA_WITH_NVENC
+    NVENCAPI = MakeUnique<FNVENCAPI>();
+#endif
+}
+
+FPanoramaNVENCEncoder::~FPanoramaNVENCEncoder()
+{
+    Shutdown();
+}
+
+void FPanoramaNVENCEncoder::Initialize(const FPanoramicVideoSettings& Settings, const FString& OutputDirectory)
+{
+    FScopeLock Lock(&CriticalSection);
+
+    CachedSettings = Settings;
+    TargetDirectory = OutputDirectory;
+    EncodedFrameCount = 0;
+    EncodedResolution = Settings.Resolution;
+    LastVideoPTS = 0.0;
+    bSupportsZeroCopy = false;
+    bZeroCopyRequested = (Settings.ColorFormat == EPanoramaColorFormat::BGRA8) ||
+        (Settings.ColorFormat == EPanoramaColorFormat::NV12) ||
+        (Settings.ColorFormat == EPanoramaColorFormat::P010 && Settings.bUseHEVC);
+    ZeroCopyDiagnostic.Reset();
+    RawVideoHandle.Reset();
+
+    if (!TargetDirectory.IsEmpty())
+    {
+        IFileManager::Get().MakeDirectory(*TargetDirectory, true);
+    }
+
+    InitializeEncoderResources(Settings);
+
+    if (!bZeroCopyRequested && ZeroCopyDiagnostic.IsEmpty())
+    {
+        ZeroCopyDiagnostic = TEXT("Zero-copy disabled for current configuration; using CPU color conversion.");
+    }
+
+    FString RawFileName;
+    if (bSupportsZeroCopy && CachedSettings.bUseHEVC)
+    {
+        RawFileName = TEXT("PanoramaCapture.hevc");
+    }
+    else if (bSupportsZeroCopy)
+    {
+        RawFileName = TEXT("PanoramaCapture.h264");
+    }
+    else
+    {
+        switch (CachedSettings.ColorFormat)
+        {
+        case EPanoramaColorFormat::NV12:
+            RawFileName = TEXT("PanoramaCapture_NV12.raw");
+            break;
+        case EPanoramaColorFormat::P010:
+            RawFileName = TEXT("PanoramaCapture_P010.raw");
+            break;
+        case EPanoramaColorFormat::BGRA8:
+            RawFileName = TEXT("PanoramaCapture_BGRA.raw");
+            break;
+        default:
+            RawFileName = TEXT("PanoramaCapture.raw");
+            break;
+        }
+    }
+
+    RawVideoPath = FPaths::Combine(TargetDirectory, RawFileName);
+
+    if (IFileManager::Get().FileExists(*RawVideoPath))
+    {
+        IFileManager::Get().Delete(*RawVideoPath);
+    }
+
+    bInitialized = true;
+}
+
+void FPanoramaNVENCEncoder::Shutdown()
+{
+    FScopeLock Lock(&CriticalSection);
+#if PANORAMA_WITH_NVENC
+    if (EncoderInstance && NVENCAPI.IsValid() && NVENCAPI->bLoaded)
+    {
+        NVENCAPI->FunctionList.nvEncDestroyEncoder(EncoderInstance);
+        EncoderInstance = nullptr;
+    }
+#endif
+    bInitialized = false;
+    CodecName.Reset();
+    Bitrate = 0;
+    CachedSettings = FPanoramicVideoSettings();
+    TargetDirectory.Reset();
+    RawVideoPath.Reset();
+    RawVideoHandle.Reset();
+    EncodedFrameCount = 0;
+    EncodedResolution = FIntPoint::ZeroValue;
+    LastVideoPTS = 0.0;
+    bSupportsZeroCopy = false;
+    bZeroCopyRequested = false;
+    ZeroCopyDiagnostic.Reset();
+}
+
+void FPanoramaNVENCEncoder::InitializeEncoderResources(const FPanoramicVideoSettings& Settings)
+{
+#if PANORAMA_WITH_NVENC
+    ZeroCopyDiagnostic.Reset();
+    bSupportsZeroCopy = false;
+    auto AppendDiagnosticLine = [](FString& Target, const FString& Line)
+    {
+        if (Line.IsEmpty())
+        {
+            return;
+        }
+        if (!Target.IsEmpty())
+        {
+            Target += TEXT("\n");
+        }
+        Target += Line;
+    };
+    auto LogZeroCopyInfo = [this, AppendDiagnosticLine](const FString& Message)
+    {
+        AppendDiagnosticLine(ZeroCopyDiagnostic, Message);
+        UE_LOG(LogPanoramaCapture, Log, TEXT("%s"), *Message);
+    };
+    auto LogZeroCopyWarning = [this, AppendDiagnosticLine](const FString& Message)
+    {
+        AppendDiagnosticLine(ZeroCopyDiagnostic, Message);
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("%s"), *Message);
+    };
+
+    CodecName = Settings.bUseHEVC ? TEXT("HEVC") : TEXT("H264");
+    Bitrate = Settings.TargetBitrateMbps;
+    UE_LOG(LogPanoramaCapture, Log, TEXT("Initializing NVENC pipeline (codec=%s bitrate=%dMbps res=%dx%d)"), *CodecName, Bitrate, Settings.Resolution.X, Settings.Resolution.Y);
+
+    if (Settings.ColorFormat == EPanoramaColorFormat::P010 && !Settings.bUseHEVC)
+    {
+        LogZeroCopyWarning(TEXT("P010 output selected without HEVC Main10 support; zero-copy will be disabled."));
+    }
+
+    if (!NVENCAPI.IsValid() || !NVENCAPI->bLoaded)
+    {
+        LogZeroCopyWarning(TEXT("NVENC API not available - zero-copy disabled; using CPU color conversion."));
+        return;
+    }
+
+    if (!GDynamicRHI)
+    {
+        LogZeroCopyWarning(TEXT("DynamicRHI is null - zero-copy unavailable."));
+        return;
+    }
+
+    void* NativeDevice = GDynamicRHI->RHIGetNativeDevice();
+    if (!NativeDevice)
+    {
+        LogZeroCopyWarning(TEXT("Failed to retrieve native RHI device for NVENC - zero-copy disabled."));
+        return;
+    }
+
+    const ERHIInterfaceType InterfaceType = GDynamicRHI->GetInterfaceType();
+
+    NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS OpenParams = {};
+    OpenParams.version = NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER;
+    OpenParams.device = NativeDevice;
+    OpenParams.deviceType = (InterfaceType == ERHIInterfaceType::D3D12) ? NV_ENC_DEVICE_TYPE_DIRECTX12 : NV_ENC_DEVICE_TYPE_DIRECTX;
+
+    NVENCSTATUS Status = NVENCAPI->FunctionList.nvEncOpenEncodeSessionEx(&OpenParams, &EncoderInstance);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        LogZeroCopyWarning(FString::Printf(TEXT("nvEncOpenEncodeSessionEx failed (status=%d) - zero-copy unavailable."), static_cast<int32>(Status)));
+        EncoderInstance = nullptr;
+        return;
+    }
+
+    FMemory::Memzero(InitializeParams);
+    FMemory::Memzero(EncoderConfig);
+    InitializeParams.version = NV_ENC_INITIALIZE_PARAMS_VER;
+    EncoderConfig.version = NV_ENC_CONFIG_VER;
+    InitializeParams.encodeGUID = Settings.bUseHEVC ? NV_ENC_CODEC_HEVC_GUID : NV_ENC_CODEC_H264_GUID;
+    NV_ENC_PRESET_GUID ChosenPreset = NV_ENC_PRESET_P4_GUID; // balanced quality
+    uint32 RateControlMode = NV_ENC_PARAMS_RC_VBR;
+    uint32 MultiPass = NV_ENC_TWO_PASS_QUARTER_RESOLUTION;
+    uint32 EnableAQ = 1;
+    uint32 EnableTemporalAQ = 0;
+
+    switch (Settings.RateControlPreset)
+    {
+    case EPanoramaRateControlPreset::LowLatency:
+        ChosenPreset = NV_ENC_PRESET_LOW_LATENCY_HQ_GUID;
+        RateControlMode = NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ;
+        MultiPass = NV_ENC_TWO_PASS_QUARTER_RESOLUTION;
+        EnableAQ = 0;
+        EnableTemporalAQ = 0;
+        break;
+    case EPanoramaRateControlPreset::HighQuality:
+        ChosenPreset = Settings.bUseHEVC ? NV_ENC_PRESET_P7_GUID : NV_ENC_PRESET_P5_GUID;
+        RateControlMode = NV_ENC_PARAMS_RC_2_PASS_QUALITY;
+        MultiPass = NV_ENC_TWO_PASS_FULL_RESOLUTION;
+        EnableAQ = 1;
+        EnableTemporalAQ = 1;
+        break;
+    default:
+        ChosenPreset = NV_ENC_PRESET_P4_GUID;
+        RateControlMode = NV_ENC_PARAMS_RC_VBR;
+        MultiPass = NV_ENC_TWO_PASS_QUARTER_RESOLUTION;
+        EnableAQ = 1;
+        EnableTemporalAQ = Settings.bUseHEVC ? 1 : 0;
+        break;
+    }
+
+    InitializeParams.presetGUID = ChosenPreset;
+    InitializeParams.encodeWidth = Settings.Resolution.X;
+    InitializeParams.encodeHeight = Settings.Resolution.Y;
+    InitializeParams.darWidth = Settings.Resolution.X;
+    InitializeParams.darHeight = Settings.Resolution.Y;
+    InitializeParams.frameRateNum = 60000;
+    InitializeParams.frameRateDen = 1000;
+    InitializeParams.enablePTD = 1;
+    InitializeParams.maxEncodeWidth = Settings.Resolution.X;
+    InitializeParams.maxEncodeHeight = Settings.Resolution.Y;
+    InitializeParams.encodeConfig = &EncoderConfig;
+    InitializeParams.enableOutputInVidmem = 1;
+
+    NV_ENC_BUFFER_FORMAT RequestedFormat = NV_ENC_BUFFER_FORMAT_ARGB;
+    switch (Settings.ColorFormat)
+    {
+    case EPanoramaColorFormat::NV12:
+        RequestedFormat = NV_ENC_BUFFER_FORMAT_NV12_PL;
+        break;
+    case EPanoramaColorFormat::P010:
+        RequestedFormat = NV_ENC_BUFFER_FORMAT_YUV420_10BIT;
+        break;
+    case EPanoramaColorFormat::BGRA8:
+    default:
+        RequestedFormat = NV_ENC_BUFFER_FORMAT_ARGB;
+        break;
+    }
+    InitializeParams.bufferFormat = RequestedFormat;
+
+    EncoderConfig.profileGUID = Settings.bUseHEVC ? NV_ENC_HEVC_PROFILE_MAIN_GUID : NV_ENC_H264_HIGH_GUID;
+    EncoderConfig.gopLength = Settings.GOPLength;
+    EncoderConfig.frameIntervalP = FMath::Max(1, Settings.NumBFrames + 1);
+    EncoderConfig.rcParams.rateControlMode = RateControlMode;
+    EncoderConfig.rcParams.multiPass = MultiPass;
+    const uint32 TargetBitrate = static_cast<uint32>(Bitrate * 1000000);
+    EncoderConfig.rcParams.averageBitRate = TargetBitrate;
+    EncoderConfig.rcParams.maxBitRate = TargetBitrate;
+    EncoderConfig.rcParams.vbvBufferSize = TargetBitrate / 8;
+    EncoderConfig.rcParams.vbvInitialDelay = EncoderConfig.rcParams.vbvBufferSize;
+    EncoderConfig.rcParams.enableAQ = EnableAQ;
+    EncoderConfig.rcParams.enableTemporalAQ = EnableTemporalAQ;
+
+    if (Settings.bUseHEVC)
+    {
+        EncoderConfig.encodeCodecConfig.hevcConfig.pixelBitDepthMinus8 = (Settings.ColorFormat == EPanoramaColorFormat::P010) ? 2 : 0;
+        EncoderConfig.encodeCodecConfig.hevcConfig.chromaFormatIDC = 1; // 4:2:0
+    }
+    else
+    {
+        EncoderConfig.encodeCodecConfig.h264Config.idrPeriod = Settings.GOPLength;
+        EncoderConfig.encodeCodecConfig.h264Config.enableFillerDataInsertion = 1;
+    }
+
+    Status = NVENCAPI->FunctionList.nvEncInitializeEncoder(EncoderInstance, &InitializeParams);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        LogZeroCopyWarning(FString::Printf(TEXT("nvEncInitializeEncoder failed (status=%d) - zero-copy unavailable."), static_cast<int32>(Status)));
+        NVENCAPI->FunctionList.nvEncDestroyEncoder(EncoderInstance);
+        EncoderInstance = nullptr;
+        return;
+    }
+
+    const bool bWantsP010 = (Settings.ColorFormat == EPanoramaColorFormat::P010);
+    bool bMain10Supported = false;
+    bool bQueriedMain10 = false;
+    bool bQueriedP010Direct = false;
+    bool bP010DirectSupported = false;
+
+    if (bWantsP010 && Settings.bUseHEVC)
+    {
+        const int32 TenBitCaps = QueryEncodeCapability(NV_ENC_CAPS_SUPPORT_10BIT_ENCODE);
+        bQueriedMain10 = true;
+        bMain10Supported = (TenBitCaps > 0);
+        if (bMain10Supported)
+        {
+            LogZeroCopyInfo(TEXT("NVENC hardware reports HEVC Main10 encode support."));
+        }
+
+#if defined(NV_ENC_CAPS_SUPPORT_INPUT_YUV10BIT)
+        const int32 DirectCaps = QueryEncodeCapability(NV_ENC_CAPS_SUPPORT_INPUT_YUV10BIT);
+        bQueriedP010Direct = true;
+        bP010DirectSupported = (DirectCaps > 0);
+        if (bP010DirectSupported)
+        {
+            LogZeroCopyInfo(TEXT("NVENC hardware accepts P010 DirectX textures for zero-copy submissions."));
+        }
+#endif
+    }
+
+    if (Settings.ColorFormat == EPanoramaColorFormat::BGRA8)
+    {
+        bSupportsZeroCopy = true;
+        LogZeroCopyInfo(TEXT("NVENC zero-copy active with BGRA8 submission."));
+    }
+    else if (Settings.ColorFormat == EPanoramaColorFormat::NV12)
+    {
+        bSupportsZeroCopy = true;
+        LogZeroCopyInfo(TEXT("NVENC zero-copy active with NV12 submission."));
+    }
+    else if (Settings.ColorFormat == EPanoramaColorFormat::P010)
+    {
+        if (!Settings.bUseHEVC)
+        {
+            LogZeroCopyWarning(TEXT("P010 zero-copy requires HEVC Main10; using CPU copy path."));
+        }
+        else if (bQueriedMain10 && !bMain10Supported)
+        {
+            LogZeroCopyWarning(TEXT("NVENC hardware lacks HEVC Main10 capability; zero-copy disabled for P010."));
+        }
+#if defined(NV_ENC_CAPS_SUPPORT_INPUT_YUV10BIT)
+        else if (bQueriedP010Direct && !bP010DirectSupported)
+        {
+            LogZeroCopyWarning(TEXT("NVENC hardware cannot accept P010 DirectX textures; zero-copy disabled."));
+        }
+#endif
+        else
+        {
+            bSupportsZeroCopy = true;
+            LogZeroCopyInfo(TEXT("NVENC zero-copy active with P010 submission."));
+        }
+    }
+    else
+    {
+        LogZeroCopyWarning(TEXT("Selected color format does not expose a zero-copy path; using CPU conversion."));
+    }
+#else
+    ZeroCopyDiagnostic = TEXT("NVENC support is not compiled; zero-copy unavailable.");
+    UE_LOG(LogPanoramaCapture, Warning, TEXT("InitializeEncoderResources called without NVENC support."));
+#endif
+}
+
+bool FPanoramaNVENCEncoder::EncodeFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+    if (!Frame.IsValid())
+    {
+        return false;
+    }
+
+    FScopeLock Lock(&CriticalSection);
+    if (!bInitialized)
+    {
+        return false;
+    }
+
+    if (bSupportsZeroCopy && Frame->NVENCTexture.IsValid())
+    {
+        const bool bResult = EncodeFrameZeroCopy(Frame);
+        Frame->LinearPixels.Reset();
+        Frame->PlanarVideo.Reset();
+        return bResult;
+    }
+
+    FIntPoint OutputResolution = Frame->Resolution;
+    TArray<uint8> EncodedPayload;
+    if (!ConvertFrameToRawPayload(Frame, EncodedPayload, OutputResolution))
+    {
+        return false;
+    }
+
+    Frame->EncodedVideo = MoveTemp(EncodedPayload);
+    Frame->LinearPixels.Reset();
+    Frame->PlanarVideo.Reset();
+    Frame->bIsStereo = false;
+    Frame->Resolution = OutputResolution;
+    Frame->ColorFormat = CachedSettings.ColorFormat;
+    WritePacketToDisk(Frame->EncodedVideo);
+    ++EncodedFrameCount;
+    EncodedResolution = Frame->Resolution;
+    LastVideoPTS = Frame->TimestampSeconds;
+    return true;
+}
+
+TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> FPanoramaNVENCEncoder::EncodeStereoPair(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame)
+{
+    if (!LeftFrame.IsValid() || !RightFrame.IsValid())
+    {
+        return nullptr;
+    }
+
+    FScopeLock Lock(&CriticalSection);
+    if (!bInitialized)
+    {
+        return nullptr;
+    }
+
+    if (bSupportsZeroCopy && LeftFrame->NVENCTexture.IsValid())
+    {
+        if (EncodeFrameZeroCopy(LeftFrame))
+        {
+            LeftFrame->LinearPixels.Reset();
+            LeftFrame->PlanarVideo.Reset();
+            RightFrame->LinearPixels.Reset();
+            RightFrame->PlanarVideo.Reset();
+            return LeftFrame;
+        }
+        return nullptr;
+    }
+
+    TArray<uint8> EncodedPayload;
+    FIntPoint CombinedResolution = FIntPoint::ZeroValue;
+    if (!ConvertStereoToRawPayload(LeftFrame, RightFrame, EncodedPayload, CombinedResolution))
+    {
+        return nullptr;
+    }
+
+    LeftFrame->EncodedVideo = MoveTemp(EncodedPayload);
+    LeftFrame->LinearPixels.Reset();
+    LeftFrame->PlanarVideo.Reset();
+    RightFrame->LinearPixels.Reset();
+    RightFrame->PlanarVideo.Reset();
+    LeftFrame->bIsStereo = true;
+    LeftFrame->Resolution = CombinedResolution;
+    LeftFrame->ColorFormat = CachedSettings.ColorFormat;
+    RightFrame->ColorFormat = CachedSettings.ColorFormat;
+    RightFrame->Resolution = CombinedResolution;
+    LeftFrame->TimestampSeconds = FMath::Min(LeftFrame->TimestampSeconds, RightFrame->TimestampSeconds);
+    WritePacketToDisk(LeftFrame->EncodedVideo);
+    ++EncodedFrameCount;
+    EncodedResolution = CombinedResolution;
+    LastVideoPTS = LeftFrame->TimestampSeconds;
+    return LeftFrame;
+}
+
+void FPanoramaNVENCEncoder::Flush()
+{
+    FScopeLock Lock(&CriticalSection);
+#if PANORAMA_WITH_NVENC
+    if (bSupportsZeroCopy && EncoderInstance && NVENCAPI.IsValid() && NVENCAPI->bLoaded)
+    {
+        NV_ENC_PIC_PARAMS PicParams = {};
+        PicParams.version = NV_ENC_PIC_PARAMS_VER;
+        PicParams.encodePicFlags = NV_ENC_PIC_FLAG_EOS;
+        NVENCAPI->FunctionList.nvEncEncodePicture(EncoderInstance, &PicParams);
+    }
+#endif
+    if (RawVideoHandle.IsValid())
+    {
+        RawVideoHandle->Flush();
+        RawVideoHandle.Reset();
+    }
+}
+
+void FPanoramaNVENCEncoder::EnsureRawFile()
+{
+    if (RawVideoHandle.IsValid())
+    {
+        return;
+    }
+
+    IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+    RawVideoHandle.Reset(PlatformFile.OpenWrite(*RawVideoPath, true));
+    if (!RawVideoHandle.IsValid())
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to open NVENC raw output file %s"), *RawVideoPath);
+    }
+}
+
+bool FPanoramaNVENCEncoder::EncodeFrameZeroCopy(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+{
+#if PANORAMA_WITH_NVENC
+    if (!Frame.IsValid() || !EncoderInstance || !NVENCAPI.IsValid() || !NVENCAPI->bLoaded)
+    {
+        return false;
+    }
+
+    if (!Frame->NVENCTexture.IsValid())
+    {
+        return false;
+    }
+
+    NV_ENC_BUFFER_FORMAT BufferFormat = NV_ENC_BUFFER_FORMAT_ARGB;
+    switch (CachedSettings.ColorFormat)
+    {
+    case EPanoramaColorFormat::BGRA8:
+        BufferFormat = NV_ENC_BUFFER_FORMAT_ARGB;
+        break;
+    case EPanoramaColorFormat::NV12:
+        BufferFormat = NV_ENC_BUFFER_FORMAT_NV12_PL;
+        break;
+    case EPanoramaColorFormat::P010:
+        BufferFormat = NV_ENC_BUFFER_FORMAT_YUV420_10BIT;
+        break;
+    default:
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC zero-copy requested with unsupported color format %d"), static_cast<int32>(CachedSettings.ColorFormat));
+        return false;
+    }
+
+    EnsureRawFile();
+
+    void* NativeResource = Frame->NVENCTexture->GetNativeResource();
+    if (!NativeResource)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC zero-copy submission failed: native texture resource missing."));
+        return false;
+    }
+
+    const FIntPoint InputResolution = Frame->NVENCResolution;
+    if (InputResolution.X <= 0 || InputResolution.Y <= 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC zero-copy submission failed: invalid resolution %dx%d."), InputResolution.X, InputResolution.Y);
+        return false;
+    }
+
+    const ERHIInterfaceType InterfaceType = GDynamicRHI ? GDynamicRHI->GetInterfaceType() : ERHIInterfaceType::Null;
+
+    NV_ENC_REGISTER_RESOURCE RegisterParams = {};
+    RegisterParams.version = NV_ENC_REGISTER_RESOURCE_VER;
+    RegisterParams.resourceType = (InterfaceType == ERHIInterfaceType::D3D12) ? NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX12 : NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX;
+    RegisterParams.resourceToRegister = NativeResource;
+    RegisterParams.width = InputResolution.X;
+    RegisterParams.height = InputResolution.Y;
+    RegisterParams.pitch = 0;
+    RegisterParams.bufferFormat = BufferFormat;
+
+    NVENCSTATUS Status = NVENCAPI->FunctionList.nvEncRegisterResource(EncoderInstance, &RegisterParams);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("nvEncRegisterResource failed (status=%d)"), static_cast<int32>(Status));
+        return false;
+    }
+
+    NV_ENC_MAP_INPUT_RESOURCE MapParams = {};
+    MapParams.version = NV_ENC_MAP_INPUT_RESOURCE_VER;
+    MapParams.registeredResource = RegisterParams.registeredResource;
+    Status = NVENCAPI->FunctionList.nvEncMapInputResource(EncoderInstance, &MapParams);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("nvEncMapInputResource failed (status=%d)"), static_cast<int32>(Status));
+        NVENCAPI->FunctionList.nvEncUnregisterResource(EncoderInstance, RegisterParams.registeredResource);
+        return false;
+    }
+
+    NV_ENC_CREATE_BITSTREAM_BUFFER CreateParams = {};
+    CreateParams.version = NV_ENC_CREATE_BITSTREAM_BUFFER_VER;
+    Status = NVENCAPI->FunctionList.nvEncCreateBitstreamBuffer(EncoderInstance, &CreateParams);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("nvEncCreateBitstreamBuffer failed (status=%d)"), static_cast<int32>(Status));
+        NVENCAPI->FunctionList.nvEncUnmapInputResource(EncoderInstance, MapParams.mappedResource);
+        NVENCAPI->FunctionList.nvEncUnregisterResource(EncoderInstance, RegisterParams.registeredResource);
+        return false;
+    }
+
+    NV_ENC_PIC_PARAMS PicParams = {};
+    PicParams.version = NV_ENC_PIC_PARAMS_VER;
+    PicParams.inputBuffer = MapParams.mappedResource;
+    PicParams.bufferFmt = BufferFormat;
+    PicParams.inputWidth = InputResolution.X;
+    PicParams.inputHeight = InputResolution.Y;
+    PicParams.outputBitstream = CreateParams.bitstreamBuffer;
+    PicParams.pictureStruct = NV_ENC_PIC_STRUCT_FRAME;
+    PicParams.inputTimeStamp = static_cast<uint64>(Frame->TimestampSeconds * 1000.0);
+
+    Status = NVENCAPI->FunctionList.nvEncEncodePicture(EncoderInstance, &PicParams);
+    if (Status != NV_ENC_SUCCESS && Status != NV_ENC_ERR_NEED_MORE_INPUT)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("nvEncEncodePicture failed (status=%d)"), static_cast<int32>(Status));
+        NVENCAPI->FunctionList.nvEncDestroyBitstreamBuffer(EncoderInstance, CreateParams.bitstreamBuffer);
+        NVENCAPI->FunctionList.nvEncUnmapInputResource(EncoderInstance, MapParams.mappedResource);
+        NVENCAPI->FunctionList.nvEncUnregisterResource(EncoderInstance, RegisterParams.registeredResource);
+        return false;
+    }
+
+    NV_ENC_LOCK_BITSTREAM LockParams = {};
+    LockParams.version = NV_ENC_LOCK_BITSTREAM_VER;
+    LockParams.outputBitstream = CreateParams.bitstreamBuffer;
+    LockParams.doNotWait = false;
+
+    Status = NVENCAPI->FunctionList.nvEncLockBitstream(EncoderInstance, &LockParams);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("nvEncLockBitstream failed (status=%d)"), static_cast<int32>(Status));
+        NVENCAPI->FunctionList.nvEncDestroyBitstreamBuffer(EncoderInstance, CreateParams.bitstreamBuffer);
+        NVENCAPI->FunctionList.nvEncUnmapInputResource(EncoderInstance, MapParams.mappedResource);
+        NVENCAPI->FunctionList.nvEncUnregisterResource(EncoderInstance, RegisterParams.registeredResource);
+        return false;
+    }
+
+    Frame->EncodedVideo.SetNumUninitialized(LockParams.bitstreamSizeInBytes);
+    if (LockParams.bitstreamSizeInBytes > 0 && LockParams.bitstreamBufferPtr)
+    {
+        FMemory::Memcpy(Frame->EncodedVideo.GetData(), LockParams.bitstreamBufferPtr, LockParams.bitstreamSizeInBytes);
+    }
+
+    NVENCAPI->FunctionList.nvEncUnlockBitstream(EncoderInstance, CreateParams.bitstreamBuffer);
+    NVENCAPI->FunctionList.nvEncDestroyBitstreamBuffer(EncoderInstance, CreateParams.bitstreamBuffer);
+    NVENCAPI->FunctionList.nvEncUnmapInputResource(EncoderInstance, MapParams.mappedResource);
+    NVENCAPI->FunctionList.nvEncUnregisterResource(EncoderInstance, RegisterParams.registeredResource);
+
+    WritePacketToDisk(Frame->EncodedVideo);
+    ++EncodedFrameCount;
+    EncodedResolution = InputResolution;
+    LastVideoPTS = Frame->TimestampSeconds;
+    Frame->bIsStereo = CachedSettings.CaptureMode == EPanoramaCaptureMode::Stereo;
+    Frame->Resolution = InputResolution;
+    Frame->ColorFormat = CachedSettings.ColorFormat;
+    return Frame->EncodedVideo.Num() > 0;
+#else
+    UE_UNUSED(Frame);
+    return false;
+#endif
+}
+
+bool FPanoramaNVENCEncoder::ConvertFrameToRawPayload(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame, TArray<uint8>& OutData, FIntPoint& OutResolution) const
+{
+    if (!Frame.IsValid())
+    {
+        return false;
+    }
+
+    OutResolution = Frame->Resolution;
+
+    switch (CachedSettings.ColorFormat)
+    {
+    case EPanoramaColorFormat::NV12:
+    {
+        const int32 Width = Frame->Resolution.X;
+        const int32 Height = Frame->Resolution.Y;
+        const int32 ExpectedBytes = Width * Height + (Width * Height) / 2;
+        if (Frame->PlanarVideo.Num() == ExpectedBytes)
+        {
+            OutData = Frame->PlanarVideo;
+            return true;
+        }
+        FNV12PlaneBuffers Planes;
+        if (!ConvertLinearToNV12Planes(Frame->LinearPixels, Frame->Resolution, CachedSettings.Gamma, Planes))
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to convert frame to NV12 (resolution %dx%d)"), Frame->Resolution.X, Frame->Resolution.Y);
+            return false;
+        }
+        CollapsePlanesToNV12(Planes, OutData);
+        return true;
+    }
+    case EPanoramaColorFormat::P010:
+    {
+        const int32 Width = Frame->Resolution.X;
+        const int32 Height = Frame->Resolution.Y;
+        const int32 ExpectedSamples = Width * Height + (Width * Height) / 2;
+        const int32 ExpectedBytes = ExpectedSamples * sizeof(uint16);
+        if (Frame->PlanarVideo.Num() == ExpectedBytes)
+        {
+            OutData = Frame->PlanarVideo;
+            return true;
+        }
+        FP010PlaneBuffers Planes;
+        if (!ConvertLinearToP010Planes(Frame->LinearPixels, Frame->Resolution, CachedSettings.Gamma, Planes))
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to convert frame to P010 (resolution %dx%d)"), Frame->Resolution.X, Frame->Resolution.Y);
+            return false;
+        }
+        CollapsePlanesToP010(Planes, OutData);
+        return true;
+    }
+    case EPanoramaColorFormat::BGRA8:
+    {
+        if (!ConvertLinearToBGRAPayload(Frame->LinearPixels, Frame->Resolution, CachedSettings.Gamma, OutData))
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to convert frame to BGRA payload (resolution %dx%d)"), Frame->Resolution.X, Frame->Resolution.Y);
+            return false;
+        }
+        return true;
+    }
+    default:
+        break;
+    }
+
+    return false;
+}
+
+bool FPanoramaNVENCEncoder::ConvertStereoToRawPayload(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame, TArray<uint8>& OutData, FIntPoint& OutResolution) const
+{
+    if (!LeftFrame.IsValid() || !RightFrame.IsValid())
+    {
+        return false;
+    }
+
+    if (LeftFrame->Resolution != RightFrame->Resolution)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Stereo frames have mismatched resolution (%dx%d vs %dx%d)"), LeftFrame->Resolution.X, LeftFrame->Resolution.Y, RightFrame->Resolution.X, RightFrame->Resolution.Y);
+        return false;
+    }
+
+    const FIntPoint BaseResolution = LeftFrame->Resolution;
+    const bool bSideBySide = CachedSettings.StereoLayout == EPanoramaStereoLayout::SideBySide;
+    OutResolution = bSideBySide ? FIntPoint(BaseResolution.X * 2, BaseResolution.Y) : FIntPoint(BaseResolution.X, BaseResolution.Y * 2);
+
+    switch (CachedSettings.ColorFormat)
+    {
+    case EPanoramaColorFormat::NV12:
+    {
+        const int32 Width = BaseResolution.X;
+        const int32 Height = BaseResolution.Y;
+        const int32 PlaneYBytes = Width * Height;
+        const int32 PlaneUVBytes = (Width * Height) / 2;
+
+        const bool bHasPlanar = LeftFrame->PlanarVideo.Num() == (PlaneYBytes + PlaneUVBytes) && RightFrame->PlanarVideo.Num() == (PlaneYBytes + PlaneUVBytes);
+        if (bHasPlanar)
+        {
+            const uint8* LeftY = LeftFrame->PlanarVideo.GetData();
+            const uint8* LeftUV = LeftY + PlaneYBytes;
+            const uint8* RightY = RightFrame->PlanarVideo.GetData();
+            const uint8* RightUV = RightY + PlaneYBytes;
+
+            if (bSideBySide)
+            {
+                const int32 CombinedWidth = Width * 2;
+                const int32 CombinedYBytes = CombinedWidth * Height;
+                const int32 CombinedUVBytes = CombinedWidth * (Height / 2);
+                OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+
+                uint8* DestY = OutData.GetData();
+                for (int32 Row = 0; Row < Height; ++Row)
+                {
+                    uint8* DestRow = DestY + Row * CombinedWidth;
+                    const uint8* LeftRow = LeftY + Row * Width;
+                    const uint8* RightRow = RightY + Row * Width;
+                    FMemory::Memcpy(DestRow, LeftRow, Width);
+                    FMemory::Memcpy(DestRow + Width, RightRow, Width);
+                }
+
+                uint8* DestUV = DestY + CombinedYBytes;
+                for (int32 Row = 0; Row < Height / 2; ++Row)
+                {
+                    uint8* DestRow = DestUV + Row * CombinedWidth;
+                    const uint8* LeftRow = LeftUV + Row * Width;
+                    const uint8* RightRow = RightUV + Row * Width;
+                    FMemory::Memcpy(DestRow, LeftRow, Width);
+                    FMemory::Memcpy(DestRow + Width, RightRow, Width);
+                }
+            }
+            else
+            {
+                const int32 CombinedYBytes = PlaneYBytes * 2;
+                const int32 CombinedUVBytes = PlaneUVBytes * 2;
+                OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+                uint8* DestPtr = OutData.GetData();
+                FMemory::Memcpy(DestPtr, LeftY, PlaneYBytes);
+                FMemory::Memcpy(DestPtr + PlaneYBytes, RightY, PlaneYBytes);
+                uint8* DestUV = DestPtr + CombinedYBytes;
+                FMemory::Memcpy(DestUV, LeftUV, PlaneUVBytes);
+                FMemory::Memcpy(DestUV + PlaneUVBytes, RightUV, PlaneUVBytes);
+            }
+            return true;
+        }
+
+        FNV12PlaneBuffers LeftPlanes;
+        FNV12PlaneBuffers RightPlanes;
+        if (!ConvertLinearToNV12Planes(LeftFrame->LinearPixels, BaseResolution, CachedSettings.Gamma, LeftPlanes))
+        {
+            return false;
+        }
+        if (!ConvertLinearToNV12Planes(RightFrame->LinearPixels, BaseResolution, CachedSettings.Gamma, RightPlanes))
+        {
+            return false;
+        }
+
+        if (bSideBySide)
+        {
+            const int32 CombinedWidth = Width * 2;
+            const int32 CombinedYBytes = CombinedWidth * Height;
+            const int32 CombinedUVBytes = CombinedWidth * (Height / 2);
+            OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+
+            uint8* DestY = OutData.GetData();
+            for (int32 Row = 0; Row < Height; ++Row)
+            {
+                uint8* DestRow = DestY + Row * CombinedWidth;
+                const uint8* LeftRow = LeftPlanes.YPlane.GetData() + Row * Width;
+                const uint8* RightRow = RightPlanes.YPlane.GetData() + Row * Width;
+                FMemory::Memcpy(DestRow, LeftRow, Width);
+                FMemory::Memcpy(DestRow + Width, RightRow, Width);
+            }
+
+            uint8* DestUV = DestY + CombinedYBytes;
+            for (int32 Row = 0; Row < Height / 2; ++Row)
+            {
+                uint8* DestRow = DestUV + Row * CombinedWidth;
+                const uint8* LeftRow = LeftPlanes.UVPlane.GetData() + Row * Width;
+                const uint8* RightRow = RightPlanes.UVPlane.GetData() + Row * Width;
+                FMemory::Memcpy(DestRow, LeftRow, Width);
+                FMemory::Memcpy(DestRow + Width, RightRow, Width);
+            }
+            return true;
+        }
+
+        const int32 CombinedYBytes = (LeftPlanes.YPlane.Num() + RightPlanes.YPlane.Num());
+        const int32 CombinedUVBytes = (LeftPlanes.UVPlane.Num() + RightPlanes.UVPlane.Num());
+        OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+
+        uint8* DestPtr = OutData.GetData();
+        FMemory::Memcpy(DestPtr, LeftPlanes.YPlane.GetData(), LeftPlanes.YPlane.Num());
+        FMemory::Memcpy(DestPtr + LeftPlanes.YPlane.Num(), RightPlanes.YPlane.GetData(), RightPlanes.YPlane.Num());
+
+        uint8* DestUV = DestPtr + CombinedYBytes;
+        FMemory::Memcpy(DestUV, LeftPlanes.UVPlane.GetData(), LeftPlanes.UVPlane.Num());
+        FMemory::Memcpy(DestUV + LeftPlanes.UVPlane.Num(), RightPlanes.UVPlane.GetData(), RightPlanes.UVPlane.Num());
+        return true;
+    }
+    case EPanoramaColorFormat::P010:
+    {
+        const int32 Width = BaseResolution.X;
+        const int32 Height = BaseResolution.Y;
+        const int32 PlaneYBytes = Width * Height * sizeof(uint16);
+        const int32 PlaneUVBytes = (Width * Height / 2) * sizeof(uint16);
+        const bool bHasPlanar = LeftFrame->PlanarVideo.Num() == (PlaneYBytes + PlaneUVBytes) && RightFrame->PlanarVideo.Num() == (PlaneYBytes + PlaneUVBytes);
+        if (bHasPlanar)
+        {
+            const uint8* LeftY = LeftFrame->PlanarVideo.GetData();
+            const uint8* LeftUV = LeftY + PlaneYBytes;
+            const uint8* RightY = RightFrame->PlanarVideo.GetData();
+            const uint8* RightUV = RightY + PlaneYBytes;
+
+            if (bSideBySide)
+            {
+                const int32 CombinedWidth = Width * 2;
+                const int32 CombinedYBytes = CombinedWidth * Height * sizeof(uint16);
+                const int32 CombinedUVBytes = CombinedWidth * (Height / 2) * sizeof(uint16);
+                OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+
+                uint8* DestY = OutData.GetData();
+                for (int32 Row = 0; Row < Height; ++Row)
+                {
+                    uint8* DestRow = DestY + Row * CombinedWidth * sizeof(uint16);
+                    const uint8* LeftRow = LeftY + Row * Width * sizeof(uint16);
+                    const uint8* RightRow = RightY + Row * Width * sizeof(uint16);
+                    FMemory::Memcpy(DestRow, LeftRow, Width * sizeof(uint16));
+                    FMemory::Memcpy(DestRow + Width * sizeof(uint16), RightRow, Width * sizeof(uint16));
+                }
+
+                uint8* DestUV = DestY + CombinedYBytes;
+                for (int32 Row = 0; Row < Height / 2; ++Row)
+                {
+                    uint8* DestRow = DestUV + Row * CombinedWidth * sizeof(uint16);
+                    const uint8* LeftRow = LeftUV + Row * Width * sizeof(uint16);
+                    const uint8* RightRow = RightUV + Row * Width * sizeof(uint16);
+                    FMemory::Memcpy(DestRow, LeftRow, Width * sizeof(uint16));
+                    FMemory::Memcpy(DestRow + Width * sizeof(uint16), RightRow, Width * sizeof(uint16));
+                }
+            }
+            else
+            {
+                const int32 CombinedYBytes = PlaneYBytes * 2;
+                const int32 CombinedUVBytes = PlaneUVBytes * 2;
+                OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+                uint8* DestPtr = OutData.GetData();
+                FMemory::Memcpy(DestPtr, LeftY, PlaneYBytes);
+                FMemory::Memcpy(DestPtr + PlaneYBytes, RightY, PlaneYBytes);
+                uint8* DestUV = DestPtr + CombinedYBytes;
+                FMemory::Memcpy(DestUV, LeftUV, PlaneUVBytes);
+                FMemory::Memcpy(DestUV + PlaneUVBytes, RightUV, PlaneUVBytes);
+            }
+            return true;
+        }
+
+        FP010PlaneBuffers LeftPlanes;
+        FP010PlaneBuffers RightPlanes;
+        if (!ConvertLinearToP010Planes(LeftFrame->LinearPixels, BaseResolution, CachedSettings.Gamma, LeftPlanes))
+        {
+            return false;
+        }
+        if (!ConvertLinearToP010Planes(RightFrame->LinearPixels, BaseResolution, CachedSettings.Gamma, RightPlanes))
+        {
+            return false;
+        }
+
+        if (bSideBySide)
+        {
+            const int32 CombinedWidth = Width * 2;
+            const int32 CombinedYBytes = CombinedWidth * Height * sizeof(uint16);
+            const int32 CombinedUVBytes = CombinedWidth * (Height / 2) * sizeof(uint16);
+            OutData.SetNumUninitialized(CombinedYBytes + CombinedUVBytes);
+
+            uint8* DestY = OutData.GetData();
+            for (int32 Row = 0; Row < Height; ++Row)
+            {
+                uint8* DestRow = DestY + Row * CombinedWidth * sizeof(uint16);
+                const uint16* LeftRow = LeftPlanes.YPlane.GetData() + Row * Width;
+                const uint16* RightRow = RightPlanes.YPlane.GetData() + Row * Width;
+                FMemory::Memcpy(DestRow, LeftRow, Width * sizeof(uint16));
+                FMemory::Memcpy(DestRow + Width * sizeof(uint16), RightRow, Width * sizeof(uint16));
+            }
+
+            uint8* DestUV = DestY + CombinedYBytes;
+            for (int32 Row = 0; Row < Height / 2; ++Row)
+            {
+                uint8* DestRow = DestUV + Row * CombinedWidth * sizeof(uint16);
+                const uint16* LeftRow = LeftPlanes.UVPlane.GetData() + Row * Width;
+                const uint16* RightRow = RightPlanes.UVPlane.GetData() + Row * Width;
+                FMemory::Memcpy(DestRow, LeftRow, Width * sizeof(uint16));
+                FMemory::Memcpy(DestRow + Width * sizeof(uint16), RightRow, Width * sizeof(uint16));
+            }
+            return true;
+        }
+
+        const int32 CombinedYElements = LeftPlanes.YPlane.Num() + RightPlanes.YPlane.Num();
+        const int32 CombinedUVElements = LeftPlanes.UVPlane.Num() + RightPlanes.UVPlane.Num();
+        const int32 TotalBytes = (CombinedYElements + CombinedUVElements) * sizeof(uint16);
+        OutData.SetNumUninitialized(TotalBytes);
+
+        uint8* DestPtr = OutData.GetData();
+        const int32 LeftYBytes = LeftPlanes.YPlane.Num() * sizeof(uint16);
+        const int32 RightYBytes = RightPlanes.YPlane.Num() * sizeof(uint16);
+        FMemory::Memcpy(DestPtr, LeftPlanes.YPlane.GetData(), LeftYBytes);
+        FMemory::Memcpy(DestPtr + LeftYBytes, RightPlanes.YPlane.GetData(), RightYBytes);
+
+        uint8* DestUV = DestPtr + (LeftYBytes + RightYBytes);
+        const int32 LeftUVBytes = LeftPlanes.UVPlane.Num() * sizeof(uint16);
+        const int32 RightUVBytes = RightPlanes.UVPlane.Num() * sizeof(uint16);
+        FMemory::Memcpy(DestUV, LeftPlanes.UVPlane.GetData(), LeftUVBytes);
+        FMemory::Memcpy(DestUV + LeftUVBytes, RightPlanes.UVPlane.GetData(), RightUVBytes);
+        return true;
+    }
+    case EPanoramaColorFormat::BGRA8:
+    {
+        TArray<uint8> LeftPixels;
+        TArray<uint8> RightPixels;
+        if (!ConvertLinearToBGRAPayload(LeftFrame->LinearPixels, BaseResolution, CachedSettings.Gamma, LeftPixels))
+        {
+            return false;
+        }
+        if (!ConvertLinearToBGRAPayload(RightFrame->LinearPixels, BaseResolution, CachedSettings.Gamma, RightPixels))
+        {
+            return false;
+        }
+
+        const int32 Width = BaseResolution.X;
+        const int32 Height = BaseResolution.Y;
+        const int32 BytesPerPixel = 4;
+        if (bSideBySide)
+        {
+            const int32 CombinedWidth = Width * 2;
+            OutData.SetNumUninitialized(CombinedWidth * Height * BytesPerPixel);
+            uint8* DestPtr = OutData.GetData();
+            for (int32 Row = 0; Row < Height; ++Row)
+            {
+                const uint8* LeftRow = LeftPixels.GetData() + Row * Width * BytesPerPixel;
+                const uint8* RightRow = RightPixels.GetData() + Row * Width * BytesPerPixel;
+                uint8* DestRow = DestPtr + Row * CombinedWidth * BytesPerPixel;
+                FMemory::Memcpy(DestRow, LeftRow, Width * BytesPerPixel);
+                FMemory::Memcpy(DestRow + Width * BytesPerPixel, RightRow, Width * BytesPerPixel);
+            }
+        }
+        else
+        {
+            OutData.SetNumUninitialized(LeftPixels.Num() + RightPixels.Num());
+            FMemory::Memcpy(OutData.GetData(), LeftPixels.GetData(), LeftPixels.Num());
+            FMemory::Memcpy(OutData.GetData() + LeftPixels.Num(), RightPixels.GetData(), RightPixels.Num());
+        }
+        return true;
+    }
+    default:
+        break;
+    }
+
+    return false;
+}
+
+void FPanoramaNVENCEncoder::WritePacketToDisk(const TArray<uint8>& PacketData)
+{
+    if (PacketData.Num() == 0)
+    {
+        return;
+    }
+
+    EnsureRawFile();
+    if (RawVideoHandle.IsValid())
+    {
+        RawVideoHandle->Write(PacketData.GetData(), PacketData.Num());
+    }
+}
+
+int32 FPanoramaNVENCEncoder::QueryEncodeCapability(NV_ENC_CAPS Capability) const
+{
+#if PANORAMA_WITH_NVENC
+    if (!EncoderInstance || !NVENCAPI.IsValid() || !NVENCAPI->bLoaded)
+    {
+        return 0;
+    }
+
+    NV_ENC_CAPS_PARAM CapsParams = {};
+    CapsParams.version = NV_ENC_CAPS_PARAM_VER;
+    CapsParams.capsToQuery = Capability;
+    int32 OutValue = 0;
+    const NVENCSTATUS Status = NVENCAPI->FunctionList.nvEncGetEncodeCaps(EncoderInstance, InitializeParams.encodeGUID, &CapsParams, &OutValue);
+    if (Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaCapture, Verbose, TEXT("nvEncGetEncodeCaps(%d) failed with status %d"), static_cast<int32>(Capability), static_cast<int32>(Status));
+        return 0;
+    }
+
+    return OutValue;
+#else
+    UE_UNUSED(Capability);
+    return 0;
+#endif
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureNVENC.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureNVENC.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RHI.h"
+#include "PanoramaCaptureTypes.h"
+#include "HAL/FileManager.h"
+
+#if PANORAMA_WITH_NVENC
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include "nvEncodeAPI.h"
+#include "Windows/HideWindowsPlatformTypes.h"
+#endif
+
+struct FPanoramaFrame;
+
+/** Lightweight wrapper around NVENC hardware encoder. */
+class FPanoramaNVENCEncoder
+{
+public:
+    FPanoramaNVENCEncoder();
+    ~FPanoramaNVENCEncoder();
+
+    void Initialize(const FPanoramicVideoSettings& Settings, const FString& OutputDirectory);
+    void Shutdown();
+
+    /**
+     * Converts a mono frame into a raw payload for the configured color format. Returns false when conversion fails.
+     */
+    bool EncodeFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+
+    /**
+     * Produces a top/bottom stereo payload (NV12/P010/BGRA) using a left/right pair. Returns the encoded (left) frame on success.
+     */
+    TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> EncodeStereoPair(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame);
+
+    void Flush();
+
+    bool IsInitialized() const { return bInitialized; }
+    bool SupportsZeroCopy() const { return bInitialized && bSupportsZeroCopy; }
+    bool WasZeroCopyRequested() const { return bZeroCopyRequested; }
+    bool HasHardware() const;
+    FString GetZeroCopyDiagnostic() const { return ZeroCopyDiagnostic; }
+
+    FString GetRawVideoPath() const { return RawVideoPath; }
+    FIntPoint GetEncodedResolution() const { return EncodedResolution; }
+    int64 GetEncodedFrameCount() const { return EncodedFrameCount; }
+    double GetLastVideoPTS() const { return LastVideoPTS; }
+    bool IsUsingHEVC() const { return CachedSettings.bUseHEVC; }
+
+private:
+    void InitializeEncoderResources(const FPanoramicVideoSettings& Settings);
+    void EnsureRawFile();
+    bool ConvertFrameToRawPayload(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame, TArray<uint8>& OutData, FIntPoint& OutResolution) const;
+    bool ConvertStereoToRawPayload(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame, TArray<uint8>& OutData, FIntPoint& OutResolution) const;
+    void WritePacketToDisk(const TArray<uint8>& PacketData);
+    bool EncodeFrameZeroCopy(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+
+    bool bInitialized;
+    bool bSupportsZeroCopy = false;
+    bool bZeroCopyRequested = false;
+    FString ZeroCopyDiagnostic;
+    FCriticalSection CriticalSection;
+
+    FString CodecName;
+    int32 Bitrate;
+    FPanoramicVideoSettings CachedSettings;
+    FString TargetDirectory;
+    FString RawVideoPath;
+    TUniquePtr<IFileHandle> RawVideoHandle;
+    int64 EncodedFrameCount;
+    FIntPoint EncodedResolution;
+    double LastVideoPTS;
+
+#if PANORAMA_WITH_NVENC
+    struct FNVENCAPI
+    {
+        FNVENCAPI();
+        NV_ENCODE_API_FUNCTION_LIST FunctionList;
+        bool bLoaded;
+    };
+
+    TUniquePtr<FNVENCAPI> NVENCAPI;
+    void* EncoderInstance = nullptr;
+    NV_ENC_CONFIG EncoderConfig;
+    NV_ENC_INITIALIZE_PARAMS InitializeParams;
+    int32 QueryEncodeCapability(NV_ENC_CAPS Capability) const;
+#endif
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureRenderer.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureRenderer.cpp
@@ -1,0 +1,619 @@
+#include "PanoramaCaptureRenderer.h"
+#include "PanoramaCaptureComponent.h"
+#include "PanoramaCaptureFrame.h"
+#include "PanoramaCaptureColorConversion.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Components/SceneCaptureComponent2D.h"
+#include "RenderGraphBuilder.h"
+#include "RenderGraphUtils.h"
+#include "GlobalShader.h"
+#include "ShaderParameterStruct.h"
+#include "ShaderParameterUtils.h"
+#include "ComputeShaderUtils.h"
+#include "RHIStaticStates.h"
+#include "RHITexture.h"
+#include "Math/UnrealMathUtility.h"
+#include "Misc/App.h"
+#include "HAL/PlatformTime.h"
+
+class FPanoramaEquirectCS : public FGlobalShader
+{
+    DECLARE_GLOBAL_SHADER(FPanoramaEquirectCS);
+    SHADER_USE_PARAMETER_STRUCT(FPanoramaEquirectCS, FGlobalShader);
+
+    BEGIN_SHADER_PARAMETER_STRUCT(FParameters, )
+        SHADER_PARAMETER(FIntPoint, OutputResolution)
+        SHADER_PARAMETER(int32, EyeIndex)
+        SHADER_PARAMETER(int32, GammaMode)
+        SHADER_PARAMETER(float, Padding)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D, FacePX)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D, FaceNX)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D, FacePY)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D, FaceNY)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D, FacePZ)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D, FaceNZ)
+        SHADER_PARAMETER_SAMPLER(SamplerState, FaceSampler)
+        SHADER_PARAMETER_RDG_TEXTURE_UAV(RWTexture2D<float4>, OutputTexture)
+    END_SHADER_PARAMETER_STRUCT()
+};
+
+IMPLEMENT_GLOBAL_SHADER(FPanoramaEquirectCS, "/PanoramaCapture/PanoramaEquirectCS.usf", "MainCS", SF_Compute);
+
+class FPanoramaConvertNVENCCS : public FGlobalShader
+{
+    DECLARE_GLOBAL_SHADER(FPanoramaConvertNVENCCS);
+    SHADER_USE_PARAMETER_STRUCT(FPanoramaConvertNVENCCS, FGlobalShader);
+
+    BEGIN_SHADER_PARAMETER_STRUCT(FParameters, )
+        SHADER_PARAMETER(FIntPoint, NVENCOutputResolution)
+        SHADER_PARAMETER(FIntPoint, NVENCSourceResolution)
+        SHADER_PARAMETER(int32, NVENCGammaMode)
+        SHADER_PARAMETER(FIntPoint, NVENCOffset)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D<float4>, NVENCSourceTexture)
+        SHADER_PARAMETER_UAV(RWTexture2D<uint4>, NVENCOutputTexture)
+    END_SHADER_PARAMETER_STRUCT()
+};
+
+IMPLEMENT_GLOBAL_SHADER(FPanoramaConvertNVENCCS, "/PanoramaCapture/PanoramaEquirectCS.usf", "ConvertToNVENCBGRA", SF_Compute);
+
+class FPanoramaConvertNVENCPlanarCS : public FGlobalShader
+{
+    DECLARE_GLOBAL_SHADER(FPanoramaConvertNVENCPlanarCS);
+    SHADER_USE_PARAMETER_STRUCT(FPanoramaConvertNVENCPlanarCS, FGlobalShader);
+
+    BEGIN_SHADER_PARAMETER_STRUCT(FParameters, )
+        SHADER_PARAMETER(FIntPoint, NVENCYResolution)
+        SHADER_PARAMETER(FIntPoint, NVENCSourceResolutionPlanar)
+        SHADER_PARAMETER(FIntPoint, NVENCOffsetPlanar)
+        SHADER_PARAMETER(FIntPoint, NVENCChromaResolution)
+        SHADER_PARAMETER(FIntPoint, NVENCChromaOffset)
+        SHADER_PARAMETER(int32, NVENCPlanarGammaMode)
+        SHADER_PARAMETER(int32, NVENCIs10Bit)
+        SHADER_PARAMETER_RDG_TEXTURE(Texture2D<float4>, NVENCSourceTexture)
+        SHADER_PARAMETER_RDG_TEXTURE_UAV(RWTexture2D<uint>, NVENCPlanarYTexture)
+        SHADER_PARAMETER_RDG_TEXTURE_UAV(RWTexture2D<uint2>, NVENCPlanarUVTexture)
+    END_SHADER_PARAMETER_STRUCT()
+};
+
+IMPLEMENT_GLOBAL_SHADER(FPanoramaConvertNVENCPlanarCS, "/PanoramaCapture/PanoramaEquirectCS.usf", "ConvertToNVENCPlanar", SF_Compute);
+
+FPanoramaCaptureRenderer::FPanoramaCaptureRenderer()
+    : bInitialized(false)
+    , PreviewIntervalSeconds(1.0f / 30.0f)
+    , LastPreviewSubmitSeconds(0.0)
+    , bPreviewUpdatesEnabled(true)
+{
+    bRenderCommandQueued = false;
+}
+
+FPanoramaCaptureRenderer::~FPanoramaCaptureRenderer()
+{
+    Shutdown();
+}
+
+void FPanoramaCaptureRenderer::Initialize()
+{
+    bInitialized = true;
+}
+
+void FPanoramaCaptureRenderer::Shutdown()
+{
+    bInitialized = false;
+    bRenderCommandQueued = false;
+    MonoTarget = nullptr;
+    StereoTarget = nullptr;
+    PreviewTarget = nullptr;
+}
+
+void FPanoramaCaptureRenderer::SetOutputTargets(UTextureRenderTarget2D* LeftTarget, UTextureRenderTarget2D* RightTarget, UTextureRenderTarget2D* InPreviewTarget, float PreviewInterval, bool bEnablePreview)
+{
+    MonoTarget = LeftTarget;
+    StereoTarget = RightTarget;
+    PreviewTarget = InPreviewTarget;
+    {
+        FScopeLock Lock(&PreviewTimingCS);
+        PreviewIntervalSeconds = (PreviewInterval > 0.f) ? PreviewInterval : 0.f;
+        bPreviewUpdatesEnabled = bEnablePreview && InPreviewTarget != nullptr;
+        LastPreviewSubmitSeconds = 0.0;
+    }
+}
+
+void FPanoramaCaptureRenderer::CaptureFrame(UPanoramaCaptureComponent* Component, const FPanoramicVideoSettings& VideoSettings, double CaptureStartTimeSeconds, bool bEnableNVENCZeroCopy, TFunction<void(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>&)> OnFrameReady)
+{
+    if (!bInitialized || bRenderCommandQueued)
+    {
+        return;
+    }
+
+    if (!Component)
+    {
+        return;
+    }
+
+    bRenderCommandQueued = true;
+    DispatchRenderCommand(Component, VideoSettings, CaptureStartTimeSeconds, bEnableNVENCZeroCopy, MoveTemp(OnFrameReady));
+}
+
+void FPanoramaCaptureRenderer::DispatchRenderCommand(UPanoramaCaptureComponent* Component, const FPanoramicVideoSettings& VideoSettings, double CaptureStartTimeSeconds, bool bEnableNVENCZeroCopy, TFunction<void(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>&)> OnFrameReady)
+{
+    UTextureRenderTarget2D* MonoTextureTarget = MonoTarget.Get();
+    if (!MonoTextureTarget)
+    {
+        bRenderCommandQueued = false;
+        return;
+    }
+
+    FTextureRenderTargetResource* MonoResource = MonoTextureTarget->GameThread_GetRenderTargetResource();
+    if (!MonoResource)
+    {
+        bRenderCommandQueued = false;
+        return;
+    }
+
+    FTexture2DRHIRef MonoTargetRHI = MonoResource->GetRenderTargetTexture();
+
+    UTextureRenderTarget2D* StereoTextureTarget = StereoTarget.Get();
+    FTexture2DRHIRef StereoTargetRHI;
+    if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo && StereoTextureTarget)
+    {
+        StereoTargetRHI = StereoTextureTarget->GameThread_GetRenderTargetResource()->GetRenderTargetTexture();
+    }
+
+    UTextureRenderTarget2D* PreviewTextureTarget = PreviewTarget.Get();
+    FTexture2DRHIRef PreviewTargetRHI;
+    if (PreviewTextureTarget)
+    {
+        if (FTextureRenderTargetResource* PreviewResource = PreviewTextureTarget->GameThread_GetRenderTargetResource())
+        {
+            PreviewTargetRHI = PreviewResource->GetRenderTargetTexture();
+        }
+    }
+
+    // Update all scene capture components before submitting render command.
+    for (USceneCaptureComponent2D* CaptureComp : Component->GetLeftEyeCaptureComponents())
+    {
+        if (CaptureComp)
+        {
+            CaptureComp->CaptureScene();
+        }
+    }
+
+    if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        for (USceneCaptureComponent2D* CaptureComp : Component->GetRightEyeCaptureComponents())
+        {
+            if (CaptureComp)
+            {
+                CaptureComp->CaptureScene();
+            }
+        }
+    }
+
+    TArray<FTexture2DRHIRef, TInlineAllocator<6>> LeftFaceTextures;
+    for (UTextureRenderTarget2D* FaceRT : Component->GetLeftEyeFaceTargets())
+    {
+        if (FaceRT)
+        {
+            FTextureRenderTargetResource* FaceResource = FaceRT->GameThread_GetRenderTargetResource();
+            if (FaceResource)
+            {
+                LeftFaceTextures.Add(FaceResource->GetRenderTargetTexture());
+            }
+        }
+    }
+
+    TArray<FTexture2DRHIRef, TInlineAllocator<6>> RightFaceTextures;
+    if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo)
+    {
+        for (UTextureRenderTarget2D* FaceRT : Component->GetRightEyeFaceTargets())
+        {
+            if (FaceRT)
+            {
+                FTextureRenderTargetResource* FaceResource = FaceRT->GameThread_GetRenderTargetResource();
+                if (FaceResource)
+                {
+                    RightFaceTextures.Add(FaceResource->GetRenderTargetTexture());
+                }
+            }
+        }
+    }
+
+    const double Timestamp = FPlatformTime::Seconds() - CaptureStartTimeSeconds;
+
+    bool bLocalPreviewEnabled = false;
+    {
+        FScopeLock Lock(&PreviewTimingCS);
+        bLocalPreviewEnabled = bPreviewUpdatesEnabled;
+    }
+
+    ENQUEUE_RENDER_COMMAND(DispatchPanoramaEquirect)([this, VideoSettings, MonoTargetRHI, StereoTargetRHI, PreviewTargetRHI, LeftFaceTextures, RightFaceTextures, Timestamp, bEnableNVENCZeroCopy, Callback = MoveTemp(OnFrameReady), bLocalPreviewEnabled](FRHICommandListImmediate& RHICmdList) mutable
+    {
+        if (!MonoTargetRHI.IsValid())
+        {
+            bRenderCommandQueued = false;
+            return;
+        }
+
+        FRDGBuilder GraphBuilder(RHICmdList);
+
+        auto RegisterFaceTextures = [&GraphBuilder](const TArray<FTexture2DRHIRef, TInlineAllocator<6>>& FaceSources)
+        {
+            TArray<FRDGTextureRef, TInlineAllocator<6>> RDGTextures;
+            RDGTextures.Reserve(FaceSources.Num());
+            for (int32 Index = 0; Index < FaceSources.Num(); ++Index)
+            {
+                if (FaceSources[Index].IsValid())
+                {
+                    RDGTextures.Add(GraphBuilder.RegisterExternalTexture(CreateRenderTarget(FaceSources[Index], *FString::Printf(TEXT("PanoramaFace_%d"), Index))));
+                }
+            }
+            return RDGTextures;
+        };
+
+        const TArray<FRDGTextureRef, TInlineAllocator<6>> LeftRDG = RegisterFaceTextures(LeftFaceTextures);
+        FRDGTextureRef OutputLeft = GraphBuilder.RegisterExternalTexture(CreateRenderTarget(MonoTargetRHI, TEXT("PanoramaEquirectLeft")));
+
+        const bool bZeroCopyEligible = bEnableNVENCZeroCopy && VideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC;
+        const bool bWantsZeroCopyBGRA = bZeroCopyEligible && VideoSettings.ColorFormat == EPanoramaColorFormat::BGRA8;
+        const bool bWantsZeroCopyPlanar = bZeroCopyEligible && (VideoSettings.ColorFormat == EPanoramaColorFormat::NV12 || (VideoSettings.ColorFormat == EPanoramaColorFormat::P010 && VideoSettings.bUseHEVC));
+
+        FRDGTextureRef NVENCCombined = nullptr;
+        FRDGTextureRef NVENCPlanarY = nullptr;
+        FRDGTextureRef NVENCPlanarUV = nullptr;
+        FTexture2DRHIRef NVENCCombinedRHI;
+        FTexture2DRHIRef NVENCPlanarCombinedRHI;
+        FIntPoint NVENCCombinedExtent = FIntPoint::ZeroValue;
+        FIntPoint NVENCChromaExtent = FIntPoint::ZeroValue;
+
+        auto ComputeCombinedExtent = [&VideoSettings](const FIntPoint& BaseExtent)
+        {
+            const bool bStereo = VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo;
+            const bool bSideBySide = bStereo && VideoSettings.StereoLayout == EPanoramaStereoLayout::SideBySide;
+            const int32 CombinedWidth = bSideBySide ? BaseExtent.X * 2 : BaseExtent.X;
+            const int32 CombinedHeight = bSideBySide ? BaseExtent.Y : BaseExtent.Y * (bStereo ? 2 : 1);
+            return FIntPoint(CombinedWidth, CombinedHeight);
+        };
+
+        if (OutputLeft)
+        {
+            const FIntPoint BaseExtent = OutputLeft->Desc.Extent;
+            if (BaseExtent.X > 0 && BaseExtent.Y > 0)
+            {
+                FIntPoint CombinedExtent = ComputeCombinedExtent(BaseExtent);
+                CombinedExtent.X = FMath::Max(2, Align(CombinedExtent.X, 2));
+                CombinedExtent.Y = FMath::Max(2, Align(CombinedExtent.Y, 2));
+                NVENCCombinedExtent = CombinedExtent;
+
+                if (bWantsZeroCopyBGRA)
+                {
+                    FRDGTextureDesc NVENCDesc = FRDGTextureDesc::Create2D(CombinedExtent, PF_B8G8R8A8, FClearValueBinding::None, TexCreate_ShaderResource | TexCreate_UAV);
+                    NVENCCombined = GraphBuilder.CreateTexture(NVENCDesc, TEXT("PanoramaNVENCBGRA"));
+                }
+                else if (bWantsZeroCopyPlanar)
+                {
+                    NVENCChromaExtent = FIntPoint(CombinedExtent.X / 2, CombinedExtent.Y / 2);
+                    const EPixelFormat LumaFormat = (VideoSettings.ColorFormat == EPanoramaColorFormat::NV12) ? PF_G8 : PF_R16_UINT;
+                    const EPixelFormat ChromaFormat = (VideoSettings.ColorFormat == EPanoramaColorFormat::NV12) ? PF_R8G8 : PF_R16G16_UINT;
+                    FRDGTextureDesc LumaDesc = FRDGTextureDesc::Create2D(CombinedExtent, LumaFormat, FClearValueBinding::None, TexCreate_ShaderResource | TexCreate_UAV);
+                    FRDGTextureDesc ChromaDesc = FRDGTextureDesc::Create2D(NVENCChromaExtent, ChromaFormat, FClearValueBinding::None, TexCreate_ShaderResource | TexCreate_UAV);
+                    NVENCPlanarY = GraphBuilder.CreateTexture(LumaDesc, TEXT("PanoramaNVENCLuma"));
+                    NVENCPlanarUV = GraphBuilder.CreateTexture(ChromaDesc, TEXT("PanoramaNVENCChroma"));
+
+                    const EPixelFormat CombinedFormat = (VideoSettings.ColorFormat == EPanoramaColorFormat::NV12) ? PF_NV12 : PF_P010;
+                    FRHITextureCreateDesc CombinedDesc = FRHITextureCreateDesc::Create2D(TEXT("PanoramaNVENCPlanarCombined"), CombinedExtent.X, CombinedExtent.Y, CombinedFormat);
+                    CombinedDesc.SetFlags(ETextureCreateFlags::ShaderResource | ETextureCreateFlags::UAV | ETextureCreateFlags::DisableSRGB);
+                    NVENCPlanarCombinedRHI = RHICreateTexture(CombinedDesc);
+                }
+            }
+        }
+
+        if (LeftRDG.Num() == 6)
+        {
+            AddPanoramaEquirectPass(GraphBuilder, LeftRDG, OutputLeft, VideoSettings, 0);
+            if (NVENCCombined)
+            {
+                AddPanoramaConvertForNVENCPass(GraphBuilder, OutputLeft, NVENCCombined, VideoSettings, 0, FIntPoint::ZeroValue);
+            }
+            else if (NVENCPlanarY && NVENCPlanarUV)
+            {
+                AddPanoramaConvertForNVENCPlanarPass(GraphBuilder, OutputLeft, NVENCPlanarY, NVENCPlanarUV, VideoSettings, 0, FIntPoint::ZeroValue, FIntPoint::ZeroValue);
+            }
+        }
+
+        FRDGTextureRef OutputRight = nullptr;
+        if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo && StereoTargetRHI.IsValid())
+        {
+            const TArray<FRDGTextureRef, TInlineAllocator<6>> RightRDG = RegisterFaceTextures(RightFaceTextures);
+            OutputRight = GraphBuilder.RegisterExternalTexture(CreateRenderTarget(StereoTargetRHI, TEXT("PanoramaEquirectRight")));
+            if (RightRDG.Num() == 6)
+            {
+                AddPanoramaEquirectPass(GraphBuilder, RightRDG, OutputRight, VideoSettings, 1);
+                if (OutputLeft)
+                {
+                    const bool bSideBySide = VideoSettings.StereoLayout == EPanoramaStereoLayout::SideBySide;
+                    const FIntPoint LeftExtent = OutputLeft->Desc.Extent;
+                    const FIntPoint DestOffset = bSideBySide ? FIntPoint(LeftExtent.X, 0) : FIntPoint(0, LeftExtent.Y);
+                    if (NVENCCombined)
+                    {
+                        AddPanoramaConvertForNVENCPass(GraphBuilder, OutputRight, NVENCCombined, VideoSettings, 1, DestOffset);
+                    }
+                    else if (NVENCPlanarY && NVENCPlanarUV)
+                    {
+                        const FIntPoint ChromaOffset(DestOffset.X / 2, DestOffset.Y / 2);
+                        AddPanoramaConvertForNVENCPlanarPass(GraphBuilder, OutputRight, NVENCPlanarY, NVENCPlanarUV, VideoSettings, 1, DestOffset, ChromaOffset);
+                    }
+                }
+            }
+        }
+
+        if (NVENCCombined)
+        {
+            GraphBuilder.QueueTextureExtraction(NVENCCombined, NVENCCombinedRHI);
+        }
+
+        FTexture2DRHIRef NVENCPlanarYRHI;
+        FTexture2DRHIRef NVENCPlanarUVRHI;
+        if (NVENCPlanarY)
+        {
+            GraphBuilder.QueueTextureExtraction(NVENCPlanarY, NVENCPlanarYRHI);
+        }
+        if (NVENCPlanarUV)
+        {
+            GraphBuilder.QueueTextureExtraction(NVENCPlanarUV, NVENCPlanarUVRHI);
+        }
+
+        GraphBuilder.Execute();
+
+        if (NVENCPlanarCombinedRHI.IsValid())
+        {
+            if (NVENCPlanarYRHI.IsValid())
+            {
+                FRHICopyTextureInfo CopyInfo;
+                CopyInfo.Size = FIntVector(NVENCCombinedExtent.X, NVENCCombinedExtent.Y, 1);
+                CopyInfo.DestSliceIndex = 0;
+                RHICmdList.CopyTexture(NVENCPlanarYRHI.GetReference(), NVENCPlanarCombinedRHI.GetReference(), CopyInfo);
+            }
+            if (NVENCPlanarUVRHI.IsValid())
+            {
+                FRHICopyTextureInfo CopyInfo;
+                CopyInfo.Size = FIntVector(NVENCChromaExtent.X, NVENCChromaExtent.Y, 1);
+                CopyInfo.DestSliceIndex = 1;
+                RHICmdList.CopyTexture(NVENCPlanarUVRHI.GetReference(), NVENCPlanarCombinedRHI.GetReference(), CopyInfo);
+            }
+        }
+
+        if (PreviewTargetRHI.IsValid())
+        {
+            bool bShouldUpdatePreview = false;
+            const double CurrentSeconds = FPlatformTime::Seconds();
+            {
+                FScopeLock Lock(&PreviewTimingCS);
+                if (bPreviewUpdatesEnabled && bLocalPreviewEnabled)
+                {
+                    if (PreviewIntervalSeconds <= 0.f)
+                    {
+                        bShouldUpdatePreview = true;
+                        LastPreviewSubmitSeconds = CurrentSeconds;
+                    }
+                    else if (CurrentSeconds - LastPreviewSubmitSeconds >= static_cast<double>(PreviewIntervalSeconds))
+                    {
+                        bShouldUpdatePreview = true;
+                        LastPreviewSubmitSeconds = CurrentSeconds;
+                    }
+                }
+            }
+
+            if (bShouldUpdatePreview && MonoTargetRHI.IsValid())
+            {
+                FRHICopyTextureInfo CopyInfo;
+                CopyInfo.Size = FIntVector(PreviewTargetRHI->GetSizeX(), PreviewTargetRHI->GetSizeY(), 1);
+                RHICmdList.CopyTexture(MonoTargetRHI.GetReference(), PreviewTargetRHI.GetReference(), CopyInfo);
+            }
+        }
+
+        auto ReadLinearPixels = [&RHICmdList](const FTexture2DRHIRef& SourceTexture, TArray<FFloat16Color>& OutPixels)
+        {
+            OutPixels.Reset();
+            if (!SourceTexture.IsValid())
+            {
+                return;
+            }
+
+            const FIntPoint Size(SourceTexture->GetSizeX(), SourceTexture->GetSizeY());
+            if (Size.X <= 0 || Size.Y <= 0)
+            {
+                return;
+            }
+
+            const FIntRect ReadRect(0, 0, Size.X, Size.Y);
+            RHICmdList.ReadSurfaceFloatData(SourceTexture, ReadRect, OutPixels, CubeFace_MAX, 0, 0);
+        };
+
+        auto PopulatePlanarPayload = [&VideoSettings](const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame)
+        {
+            if (!Frame.IsValid())
+            {
+                return;
+            }
+
+            if (VideoSettings.OutputFormat != EPanoramaOutputFormat::NVENC)
+            {
+                return;
+            }
+
+            switch (VideoSettings.ColorFormat)
+            {
+            case EPanoramaColorFormat::NV12:
+            {
+                PanoramaCapture::Color::FNV12PlaneBuffers Planes;
+                if (PanoramaCapture::Color::ConvertLinearToNV12Planes(Frame->LinearPixels, Frame->Resolution, VideoSettings.Gamma, Planes))
+                {
+                    PanoramaCapture::Color::CollapsePlanesToNV12(Planes, Frame->PlanarVideo);
+                }
+                break;
+            }
+            case EPanoramaColorFormat::P010:
+            {
+                PanoramaCapture::Color::FP010PlaneBuffers Planes;
+                if (PanoramaCapture::Color::ConvertLinearToP010Planes(Frame->LinearPixels, Frame->Resolution, VideoSettings.Gamma, Planes))
+                {
+                    PanoramaCapture::Color::CollapsePlanesToP010(Planes, Frame->PlanarVideo);
+                }
+                break;
+            }
+            default:
+                break;
+            }
+
+            if (Frame->PlanarVideo.Num() > 0)
+            {
+                Frame->LinearPixels.Reset();
+            }
+        };
+
+        if (Callback)
+        {
+            FTextureRHIRef ZeroCopyTexture;
+            if (bWantsZeroCopyBGRA && NVENCCombinedRHI.IsValid())
+            {
+                ZeroCopyTexture = NVENCCombinedRHI;
+            }
+            else if (bWantsZeroCopyPlanar && NVENCPlanarCombinedRHI.IsValid())
+            {
+                ZeroCopyTexture = NVENCPlanarCombinedRHI;
+            }
+
+            const bool bZeroCopyActive = ZeroCopyTexture.IsValid();
+
+            TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> LeftFrame = MakeShared<FPanoramaFrame, ESPMode::ThreadSafe>();
+            LeftFrame->EyeIndex = 0;
+            LeftFrame->TimestampSeconds = Timestamp;
+            LeftFrame->Format = MonoTargetRHI->GetFormat();
+            LeftFrame->bIsStereo = VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo;
+            LeftFrame->Texture = MonoTargetRHI;
+            LeftFrame->Resolution = FIntPoint(MonoTargetRHI->GetSizeX(), MonoTargetRHI->GetSizeY());
+            LeftFrame->ColorFormat = VideoSettings.ColorFormat;
+            if (VideoSettings.OutputFormat == EPanoramaOutputFormat::PNGSequence || !bZeroCopyActive)
+            {
+                ReadLinearPixels(MonoTargetRHI, LeftFrame->LinearPixels);
+            }
+            if (!bZeroCopyActive)
+            {
+                PopulatePlanarPayload(LeftFrame);
+            }
+            LeftFrame->NVENCTexture = bZeroCopyActive ? ZeroCopyTexture : nullptr;
+            LeftFrame->NVENCResolution = bZeroCopyActive ? NVENCCombinedExtent : LeftFrame->Resolution;
+            Callback(LeftFrame);
+
+            if (VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo && OutputRight)
+            {
+                TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> RightFrame = MakeShared<FPanoramaFrame, ESPMode::ThreadSafe>();
+                RightFrame->EyeIndex = 1;
+                RightFrame->TimestampSeconds = Timestamp;
+                RightFrame->Format = StereoTargetRHI.IsValid() ? StereoTargetRHI->GetFormat() : PF_FloatRGBA;
+                RightFrame->bIsStereo = true;
+                RightFrame->Texture = StereoTargetRHI;
+                RightFrame->Resolution = StereoTargetRHI.IsValid() ? FIntPoint(StereoTargetRHI->GetSizeX(), StereoTargetRHI->GetSizeY()) : LeftFrame->Resolution;
+                RightFrame->ColorFormat = VideoSettings.ColorFormat;
+                if (VideoSettings.OutputFormat == EPanoramaOutputFormat::PNGSequence || !bZeroCopyActive)
+                {
+                    ReadLinearPixels(StereoTargetRHI, RightFrame->LinearPixels);
+                }
+                if (!bZeroCopyActive)
+                {
+                    PopulatePlanarPayload(RightFrame);
+                }
+                Callback(RightFrame);
+            }
+        }
+
+        bRenderCommandQueued = false;
+    });
+}
+
+void AddPanoramaEquirectPass(FRDGBuilder& GraphBuilder, const TArray<FRDGTextureRef>& FaceTextures, FRDGTextureRef OutputTexture, const FPanoramicVideoSettings& Settings, int32 EyeIndex)
+{
+    if (FaceTextures.Num() < 6 || OutputTexture == nullptr)
+    {
+        return;
+    }
+
+    FPanoramaEquirectCS::FParameters* Parameters = GraphBuilder.AllocParameters<FPanoramaEquirectCS::FParameters>();
+    Parameters->OutputResolution = OutputTexture->Desc.Extent;
+    Parameters->EyeIndex = EyeIndex;
+    Parameters->GammaMode = static_cast<int32>(Settings.Gamma);
+    const float MaxExtent = static_cast<float>(FMath::Max(OutputTexture->Desc.Extent.X, OutputTexture->Desc.Extent.Y));
+    const float SeamFix = (MaxExtent > 0.f) ? FMath::Clamp(Settings.SeamFixTexels / MaxExtent, 0.0f, 0.25f) : 0.0f;
+    Parameters->Padding = SeamFix;
+    Parameters->FacePX = FaceTextures[0];
+    Parameters->FaceNX = FaceTextures[1];
+    Parameters->FacePY = FaceTextures[2];
+    Parameters->FaceNY = FaceTextures[3];
+    Parameters->FacePZ = FaceTextures[4];
+    Parameters->FaceNZ = FaceTextures[5];
+    Parameters->FaceSampler = TStaticSamplerState<SF_Trilinear, AM_Clamp, AM_Clamp, AM_Clamp>::GetRHI();
+    Parameters->OutputTexture = GraphBuilder.CreateUAV(FRDGTextureUAVDesc(OutputTexture));
+
+    TShaderMapRef<FPanoramaEquirectCS> ComputeShader(GetGlobalShaderMap(GMaxRHIFeatureLevel));
+
+    FIntVector GroupSize;
+    GroupSize.X = FMath::DivideAndRoundUp(OutputTexture->Desc.Extent.X, 8);
+    GroupSize.Y = FMath::DivideAndRoundUp(OutputTexture->Desc.Extent.Y, 8);
+    GroupSize.Z = 1;
+
+    FComputeShaderUtils::AddPass(GraphBuilder, RDG_EVENT_NAME("PanoramaEquirect_Eye%d", EyeIndex), ComputeShader, Parameters, GroupSize);
+}
+
+void AddPanoramaConvertForNVENCPass(FRDGBuilder& GraphBuilder, FRDGTextureRef SourceTexture, FRDGTextureRef DestTexture, const FPanoramicVideoSettings& Settings, int32 EyeIndex, const FIntPoint& DestOffset)
+{
+    if (SourceTexture == nullptr || DestTexture == nullptr)
+    {
+        return;
+    }
+
+    FPanoramaConvertNVENCCS::FParameters* Parameters = GraphBuilder.AllocParameters<FPanoramaConvertNVENCCS::FParameters>();
+    Parameters->NVENCOutputResolution = DestTexture->Desc.Extent;
+    Parameters->NVENCSourceResolution = SourceTexture->Desc.Extent;
+    Parameters->NVENCGammaMode = static_cast<int32>(Settings.Gamma);
+    Parameters->NVENCOffset = DestOffset;
+    Parameters->NVENCSourceTexture = SourceTexture;
+    Parameters->NVENCOutputTexture = GraphBuilder.CreateUAV(FRDGTextureUAVDesc(DestTexture));
+
+    const FIntPoint SourceExtent = SourceTexture->Desc.Extent;
+    FIntVector GroupSize;
+    GroupSize.X = FMath::DivideAndRoundUp(SourceExtent.X, 8);
+    GroupSize.Y = FMath::DivideAndRoundUp(SourceExtent.Y, 8);
+    GroupSize.Z = 1;
+
+    TShaderMapRef<FPanoramaConvertNVENCCS> ComputeShader(GetGlobalShaderMap(GMaxRHIFeatureLevel));
+    FComputeShaderUtils::AddPass(GraphBuilder, RDG_EVENT_NAME("PanoramaNVENCConvert_Eye%d", EyeIndex), ComputeShader, Parameters, GroupSize);
+}
+
+void AddPanoramaConvertForNVENCPlanarPass(FRDGBuilder& GraphBuilder, FRDGTextureRef SourceTexture, FRDGTextureRef LumaTexture, FRDGTextureRef ChromaTexture, const FPanoramicVideoSettings& Settings, int32 EyeIndex, const FIntPoint& LumaOffset, const FIntPoint& ChromaOffset)
+{
+    if (SourceTexture == nullptr || LumaTexture == nullptr || ChromaTexture == nullptr)
+    {
+        return;
+    }
+
+    FPanoramaConvertNVENCPlanarCS::FParameters* Parameters = GraphBuilder.AllocParameters<FPanoramaConvertNVENCPlanarCS::FParameters>();
+    Parameters->NVENCYResolution = LumaTexture->Desc.Extent;
+    Parameters->NVENCSourceResolutionPlanar = SourceTexture->Desc.Extent;
+    Parameters->NVENCOffsetPlanar = LumaOffset;
+    Parameters->NVENCChromaResolution = ChromaTexture->Desc.Extent;
+    Parameters->NVENCChromaOffset = ChromaOffset;
+    Parameters->NVENCPlanarGammaMode = static_cast<int32>(Settings.Gamma);
+    Parameters->NVENCIs10Bit = (Settings.ColorFormat == EPanoramaColorFormat::P010) ? 1 : 0;
+    Parameters->NVENCSourceTexture = SourceTexture;
+    Parameters->NVENCPlanarYTexture = GraphBuilder.CreateUAV(FRDGTextureUAVDesc(LumaTexture));
+    Parameters->NVENCPlanarUVTexture = GraphBuilder.CreateUAV(FRDGTextureUAVDesc(ChromaTexture));
+
+    const FIntPoint ChromaExtent = ChromaTexture->Desc.Extent;
+    FIntVector GroupSize;
+    GroupSize.X = FMath::DivideAndRoundUp(ChromaExtent.X, 8);
+    GroupSize.Y = FMath::DivideAndRoundUp(ChromaExtent.Y, 8);
+    GroupSize.Z = 1;
+
+    TShaderMapRef<FPanoramaConvertNVENCPlanarCS> ComputeShader(GetGlobalShaderMap(GMaxRHIFeatureLevel));
+    FComputeShaderUtils::AddPass(GraphBuilder, RDG_EVENT_NAME("PanoramaNVENCPlanar_Eye%d", EyeIndex), ComputeShader, Parameters, GroupSize);
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureRenderer.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureRenderer.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RHI.h"
+#include "PanoramaCaptureTypes.h"
+
+class UPanoramaCaptureComponent;
+class UTextureRenderTarget2D;
+struct FPanoramaFrame;
+
+/** Responsible for issuing scene capture updates and dispatching the equirect compute shader. */
+class FRDGBuilder;
+
+class FPanoramaCaptureRenderer
+{
+public:
+    FPanoramaCaptureRenderer();
+    ~FPanoramaCaptureRenderer();
+
+    void Initialize();
+    void Shutdown();
+
+    bool IsInitialized() const { return bInitialized; }
+
+    void CaptureFrame(UPanoramaCaptureComponent* Component, const FPanoramicVideoSettings& VideoSettings, double CaptureStartTimeSeconds, bool bEnableNVENCZeroCopy, TFunction<void(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>&)> OnFrameReady);
+
+    void SetOutputTargets(UTextureRenderTarget2D* LeftTarget, UTextureRenderTarget2D* RightTarget, UTextureRenderTarget2D* PreviewTarget, float PreviewInterval, bool bPreviewEnabled);
+
+private:
+    void DispatchRenderCommand(UPanoramaCaptureComponent* Component, const FPanoramicVideoSettings& VideoSettings, double CaptureStartTimeSeconds, bool bEnableNVENCZeroCopy, TFunction<void(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>&)> OnFrameReady);
+
+    bool bInitialized;
+    TAtomic<bool> bRenderCommandQueued;
+
+    TWeakObjectPtr<UTextureRenderTarget2D> MonoTarget;
+    TWeakObjectPtr<UTextureRenderTarget2D> StereoTarget;
+    TWeakObjectPtr<UTextureRenderTarget2D> PreviewTarget;
+    float PreviewIntervalSeconds;
+    double LastPreviewSubmitSeconds;
+    bool bPreviewUpdatesEnabled;
+    FCriticalSection PreviewTimingCS;
+};
+
+void AddPanoramaEquirectPass(FRDGBuilder& GraphBuilder, const TArray<FRDGTextureRef>& FaceTextures, FRDGTextureRef OutputTexture, const FPanoramicVideoSettings& Settings, int32 EyeIndex);
+void AddPanoramaConvertForNVENCPass(FRDGBuilder& GraphBuilder, FRDGTextureRef SourceTexture, FRDGTextureRef DestTexture, const FPanoramicVideoSettings& Settings, int32 EyeIndex, const FIntPoint& DestOffset);

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureComponent.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureComponent.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Components/SceneCaptureComponent2D.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "PanoramaCaptureTypes.h"
+#include "PanoramaCaptureComponent.generated.h"
+
+class FPanoramaCaptureManager;
+class UStaticMeshComponent;
+class UMaterialInterface;
+class UMaterialInstanceDynamic;
+class USoundSubmix;
+
+/** Actor component responsible for spawning the six-face capture rig and forwarding capture requests to the manager. */
+UCLASS(ClassGroup = (Panorama), meta = (BlueprintSpawnableComponent))
+class PANORAMACAPTURE_API UPanoramaCaptureComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UPanoramaCaptureComponent();
+
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void OnRegister() override;
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    /** Start capture session. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    void StartCapture();
+
+    /** Stop capture session and flush outstanding frames. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    void StopCapture();
+
+    /** Returns true if capture currently active. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    bool IsCapturing() const;
+
+    /** Toggle preview plane visibility. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    void SetPreviewEnabled(bool bEnabled);
+
+    /** Provide copy of capture status. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    FPanoramicCaptureStatus GetCaptureStatus() const;
+
+    /** Called on UI to update ring buffer size. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    int32 GetRingBufferCapacity() const;
+
+    /** Called on UI to update ring buffer occupancy. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    int32 GetRingBufferOccupancy() const;
+
+    /** Recreate capture rig and render targets to reflect updated settings. */
+    UFUNCTION(BlueprintCallable, Category = "PanoramaCapture")
+    void ReinitializeRig();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture")
+    FPanoramicVideoSettings VideoSettings;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture")
+    FPanoramicAudioSettings AudioSettings;
+
+    /** Directory root for intermediate outputs. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture")
+    FString OutputDirectory;
+
+    /** Optional preview material instanced onto a plane mesh. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture|Preview")
+    UMaterialInterface* PreviewMaterialTemplate;
+
+    /** Target preview frame rate to avoid saturating the editor viewport. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture|Preview", meta = (ClampMin = "5.0", ClampMax = "120.0"))
+    float PreviewMaxFPS = 30.0f;
+
+    /** Fractional resolution used for the preview render target relative to the capture resolution. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture|Preview", meta = (ClampMin = "0.1", ClampMax = "1.0"))
+    float PreviewResolutionScale = 1.0f;
+
+    /** Optional submix to record instead of the master output. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PanoramaCapture|Audio")
+    TObjectPtr<USoundSubmix> SubmixToCapture;
+
+    FORCEINLINE const TArray<TObjectPtr<USceneCaptureComponent2D>>& GetLeftEyeCaptureComponents() const { return LeftEyeCaptures; }
+    FORCEINLINE const TArray<TObjectPtr<UTextureRenderTarget2D>>& GetLeftEyeFaceTargets() const { return LeftEyeFaceTargets; }
+    FORCEINLINE const TArray<TObjectPtr<USceneCaptureComponent2D>>& GetRightEyeCaptureComponents() const { return RightEyeCaptures; }
+    FORCEINLINE const TArray<TObjectPtr<UTextureRenderTarget2D>>& GetRightEyeFaceTargets() const { return RightEyeFaceTargets; }
+
+protected:
+    void CreateCaptureRig();
+    void DestroyCaptureRig();
+    void AllocateRenderTargets();
+    void UpdatePreviewMaterial();
+
+    TArray<USceneCaptureComponent2D*> GetActiveCaptureComponents() const;
+
+    void BindDelegates();
+    void UnbindDelegates();
+
+private:
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<USceneCaptureComponent2D>> LeftEyeCaptures;
+
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<UTextureRenderTarget2D>> LeftEyeFaceTargets;
+
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<USceneCaptureComponent2D>> RightEyeCaptures;
+
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<UTextureRenderTarget2D>> RightEyeFaceTargets;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UStaticMeshComponent> PreviewMeshComponent;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UMaterialInstanceDynamic> PreviewMID;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UTextureRenderTarget2D> MonoEquirectTarget;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UTextureRenderTarget2D> RightEquirectTarget;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UTextureRenderTarget2D> PreviewEquirectTarget;
+
+    TSharedPtr<FPanoramaCaptureManager> CaptureManager;
+
+    bool bPreviewRequested;
+
+    FPanoramicCaptureStatus CachedStatus;
+
+    void HandleStatusUpdated(const FPanoramicCaptureStatus& Status);
+
+    void UpdatePreviewSettingsOnManager();
+
+    FIntPoint GetPreviewResolution() const;
+
+    float GetPreviewFrameInterval() const;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureFrame.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureFrame.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RHIResources.h"
+#include "Math/Float16Color.h"
+#include "PanoramaCaptureTypes.h"
+
+/** Representation of a frame captured from the render thread. */
+struct FPanoramaFrame
+{
+    FPanoramaFrame()
+        : TimestampSeconds(0.0)
+        , EyeIndex(0)
+        , bIsStereo(false)
+        , Format(PF_FloatRGBA)
+        , Resolution(FIntPoint::ZeroValue)
+        , ColorFormat(EPanoramaColorFormat::NV12)
+    {
+    }
+
+    double TimestampSeconds;
+    int32 EyeIndex;
+    bool bIsStereo;
+    EPixelFormat Format;
+
+    FTextureRHIRef Texture;
+    FIntPoint Resolution;
+
+    /** Raw half float pixels captured from the render thread for PNG output. */
+    TArray<FFloat16Color> LinearPixels;
+
+    /** GPU-resident texture prepared for NVENC zero-copy submission (BGRA8). */
+    FTextureRHIRef NVENCTexture;
+
+    /** Resolution of the NVENC-ready texture. May differ from the float equirect target in stereo mode. */
+    FIntPoint NVENCResolution = FIntPoint::ZeroValue;
+
+    /** Location of an intermediate file written by the worker (PNG sequence). */
+    FString DiskFilePath;
+
+    /** Encoded elementary stream payload for hardware encoder output. */
+    TArray<uint8> EncodedVideo;
+
+    /** Color format used when producing EncodedVideo or NVENCTexture. */
+    EPanoramaColorFormat ColorFormat;
+
+    /** Optional planar payload generated on the GPU (NV12/P010) before NVENC submission. */
+    TArray<uint8> PlanarVideo;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureFrameQueue.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureFrameQueue.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/** Lock-free ring buffer queue for video frames. */
+template <typename ElementType>
+class TPanoramaFrameQueue
+{
+public:
+    explicit TPanoramaFrameQueue(int32 InCapacity = 120)
+        : Capacity(FMath::Max(1, InCapacity))
+    {
+        Storage.SetNumZeroed(Capacity);
+    }
+
+    bool Enqueue(const TSharedPtr<ElementType, ESPMode::ThreadSafe>& Item)
+    {
+        FScopeLock Lock(&CriticalSection);
+        const int32 NextHead = (Head + 1) % Capacity;
+        if (NextHead == Tail)
+        {
+            ++Dropped;
+            return false;
+        }
+
+        Storage[Head] = Item;
+        Head = NextHead;
+        ++Count;
+        return true;
+    }
+
+    TSharedPtr<ElementType, ESPMode::ThreadSafe> Dequeue()
+    {
+        FScopeLock Lock(&CriticalSection);
+        if (Tail == Head)
+        {
+            return nullptr;
+        }
+
+        const TSharedPtr<ElementType, ESPMode::ThreadSafe> Item = Storage[Tail];
+        Storage[Tail].Reset();
+        Tail = (Tail + 1) % Capacity;
+        --Count;
+        return Item;
+    }
+
+    void Reset()
+    {
+        FScopeLock Lock(&CriticalSection);
+        for (int32 Index = 0; Index < Capacity; ++Index)
+        {
+            Storage[Index].Reset();
+        }
+        Head = 0;
+        Tail = 0;
+        Count = 0;
+        Dropped = 0;
+    }
+
+    int32 Num() const
+    {
+        FScopeLock Lock(&CriticalSection);
+        return Count;
+    }
+
+    int32 GetCapacity() const
+    {
+        return Capacity;
+    }
+
+    int32 GetDroppedCount() const
+    {
+        FScopeLock Lock(&CriticalSection);
+        return Dropped;
+    }
+
+private:
+    mutable FCriticalSection CriticalSection;
+    TArray<TSharedPtr<ElementType, ESPMode::ThreadSafe>> Storage;
+    int32 Head = 0;
+    int32 Tail = 0;
+    int32 Count = 0;
+    int32 Capacity = 0;
+    int32 Dropped = 0;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureLog.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureLog.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogPanoramaCapture, Log, All);

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureManager.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureManager.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PanoramaCaptureTypes.h"
+#include "PanoramaCaptureFrameQueue.h"
+#include "HAL/ThreadSafeBool.h"
+
+class FPanoramaCaptureRenderer;
+class FPanoramaAudioRecorder;
+class FPanoramaFFmpegMuxer;
+class FPanoramaNVENCEncoder;
+class UPanoramaCaptureComponent;
+class FRunnableThread;
+class FEvent;
+class USoundSubmix;
+
+struct FPanoramaFrame;
+
+/** High-level orchestrator for the capture pipeline. */
+class PANORAMACAPTURE_API FPanoramaCaptureManager : public TSharedFromThis<FPanoramaCaptureManager, ESPMode::ThreadSafe>
+{
+public:
+    FPanoramaCaptureManager();
+    ~FPanoramaCaptureManager();
+
+    void Initialize(UPanoramaCaptureComponent* InOwnerComponent, const FPanoramicVideoSettings& VideoSettings, const FPanoramicAudioSettings& AudioSettings, const FString& OutputDirectory);
+    void Shutdown();
+
+    bool IsInitialized() const { return bInitialized; }
+
+    void StartCapture();
+    void StopCapture();
+
+    void EnqueueFrame_RenderThread(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+
+    FPanoramicCaptureStatus GetStatus() const;
+    int32 GetRingBufferCapacity() const;
+    int32 GetRingBufferOccupancy() const;
+
+    void Tick_GameThread(float DeltaTime);
+
+    void SetPreviewTargets_GameThread(UTextureRenderTarget2D* MonoTarget, UTextureRenderTarget2D* RightTarget, UTextureRenderTarget2D* PreviewTarget, float InPreviewInterval, bool bPreviewEnabled);
+    void SetAudioSubmix(USoundSubmix* Submix);
+
+    FPanoramaCaptureStarted OnCaptureStarted;
+    FPanoramaCaptureStopped OnCaptureStopped;
+    FPanoramaCaptureStatusUpdated OnCaptureStatusUpdated;
+
+private:
+    class FFrameProcessor;
+
+    void StartWorkers();
+    void StopWorkers();
+
+    void ProcessPendingFrames();
+    void ProcessPendingAudio();
+
+    void ProcessPendingFrames_Worker();
+    bool HandlePNGFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+    bool HandleStereoPNGPair(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame);
+    bool HandleNVENCFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+    TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> HandleStereoNVENCPair(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& LeftFrame, const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& RightFrame);
+    bool SavePNGToDisk(const FString& Filename, const TArray<FFloat16Color>& Pixels, const FIntPoint& Resolution);
+    FString BuildPNGFilePath(int32 FrameIndex) const;
+
+    void NotifyStatus_GameThread();
+    void UpdateStatusAfterVideoFrame(const TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe>& Frame);
+    void UpdateStatusAfterAudioPacket(const FPanoramaAudioPacket& Packet);
+    void ResetStatus();
+    bool PerformPreflightChecks();
+    bool VerifyDiskCapacity();
+    void ApplyFallbackIfNeeded();
+    void PushWarningMessage(const FString& Message);
+
+    TUniquePtr<FPanoramaCaptureRenderer> Renderer;
+    TUniquePtr<FPanoramaAudioRecorder> AudioRecorder;
+    TUniquePtr<FPanoramaNVENCEncoder> VideoEncoder;
+    TUniquePtr<FPanoramaFFmpegMuxer> Muxer;
+
+    FPanoramicVideoSettings CurrentVideoSettings;
+    FPanoramicAudioSettings CurrentAudioSettings;
+    FString TargetOutputDirectory;
+
+    mutable FCriticalSection StatusCriticalSection;
+    FPanoramicCaptureStatus CachedStatus;
+
+    bool bInitialized;
+    bool bCaptureRequested;
+    bool bCaptureActive;
+    double CaptureStartTimeSeconds;
+
+    FDelegateHandle TickHandle;
+
+    TPanoramaFrameQueue<FPanoramaFrame> FrameQueue;
+    TWeakObjectPtr<UPanoramaCaptureComponent> OwnerComponent;
+
+    TUniquePtr<FFrameProcessor> FrameProcessor;
+    TUniquePtr<FRunnableThread> FrameProcessorThread;
+
+    TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> PendingLeftFrame;
+    TSharedPtr<FPanoramaFrame, ESPMode::ThreadSafe> PendingNVENCLeftFrame;
+    int32 FrameCounter;
+
+    TWeakObjectPtr<UTextureRenderTarget2D> MonoTargetWeak;
+    TWeakObjectPtr<UTextureRenderTarget2D> StereoTargetWeak;
+    TWeakObjectPtr<UTextureRenderTarget2D> PreviewTargetWeak;
+    float PreviewFrameIntervalSeconds;
+    double LastPreviewUpdateSeconds;
+    bool bPreviewEnabled;
+    bool bHasFallenBack;
+    FString LastWarningMessage;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureTypes.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureTypes.h
@@ -1,0 +1,229 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PanoramaCaptureTypes.generated.h"
+
+UENUM(BlueprintType)
+enum class EPanoramaCaptureMode : uint8
+{
+    Mono,
+    Stereo
+};
+
+UENUM(BlueprintType)
+enum class EPanoramaOutputFormat : uint8
+{
+    PNGSequence,
+    NVENC
+};
+
+UENUM(BlueprintType)
+enum class EPanoramaGamma : uint8
+{
+    SRGB,
+    Linear
+};
+
+UENUM(BlueprintType)
+enum class EPanoramaStereoLayout : uint8
+{
+    TopBottom,
+    SideBySide
+};
+
+UENUM(BlueprintType)
+enum class EPanoramaRateControlPreset : uint8
+{
+    Default,
+    LowLatency,
+    HighQuality
+};
+
+UENUM(BlueprintType)
+enum class EPanoramaColorFormat : uint8
+{
+    NV12,
+    P010,
+    BGRA8
+};
+
+USTRUCT(BlueprintType)
+struct FPanoramicVideoSettings
+{
+    GENERATED_BODY()
+
+    FPanoramicVideoSettings()
+        : Resolution(FIntPoint(4096, 2048))
+        , TargetBitrateMbps(80)
+        , GOPLength(30)
+        , NumBFrames(2)
+        , bUseHEVC(true)
+        , OutputFormat(EPanoramaOutputFormat::NVENC)
+        , CaptureMode(EPanoramaCaptureMode::Mono)
+        , Gamma(EPanoramaGamma::SRGB)
+        , ColorFormat(EPanoramaColorFormat::NV12)
+        , StereoLayout(EPanoramaStereoLayout::TopBottom)
+        , SeamFixTexels(1.0f)
+        , RateControlPreset(EPanoramaRateControlPreset::Default)
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    FIntPoint Resolution;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video", meta = (ClampMin = "1"))
+    int32 TargetBitrateMbps;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video", meta = (ClampMin = "1"))
+    int32 GOPLength;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video", meta = (ClampMin = "0"))
+    int32 NumBFrames;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    bool bUseHEVC;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    EPanoramaOutputFormat OutputFormat;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    EPanoramaCaptureMode CaptureMode;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    EPanoramaGamma Gamma;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    EPanoramaColorFormat ColorFormat;
+
+    /** Layout for stereo output when CaptureMode is Stereo. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    EPanoramaStereoLayout StereoLayout;
+
+    /** Number of texels to shrink cubemap sampling to hide seams. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video", meta = (ClampMin = "0.0", ClampMax = "8.0"))
+    float SeamFixTexels;
+
+    /** NVENC rate control preset exposed in the UI. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Video")
+    EPanoramaRateControlPreset RateControlPreset;
+};
+
+USTRUCT(BlueprintType)
+struct FPanoramicAudioSettings
+{
+    GENERATED_BODY()
+
+    FPanoramicAudioSettings()
+        : SampleRate(48000)
+        , NumChannels(2)
+        , bCaptureAudio(true)
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Audio", meta = (ClampMin = "8000", ClampMax = "192000"))
+    int32 SampleRate;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Audio", meta = (ClampMin = "1", ClampMax = "8"))
+    int32 NumChannels;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Audio")
+    bool bCaptureAudio;
+};
+
+USTRUCT(BlueprintType)
+struct FPanoramicCaptureStatus
+{
+    GENERATED_BODY()
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    bool bIsCapturing = false;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    int32 PendingFrameCount = 0;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    int32 DroppedFrames = 0;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    float CurrentCaptureTimeSeconds = 0.f;
+
+    /** Last video presentation timestamp relative to capture start (seconds). */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    double LastVideoPTS = 0.0;
+
+    /** Last audio presentation timestamp relative to capture start (seconds). */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    double LastAudioPTS = 0.0;
+
+    /** Ring buffer fill ratio (0-1). */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    float RingBufferFill = 0.f;
+
+    /** True when NVENC hardware encoding is active. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    bool bUsingNVENC = false;
+
+    /** True when capture fell back to a safer configuration after preflight. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    bool bUsingFallback = false;
+
+    /** True when the current session requested zero-copy submission to NVENC. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    bool bZeroCopyRequested = false;
+
+    /** True when NVENC zero-copy submission is active. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    bool bZeroCopyActive = false;
+
+    /** Optional warning or diagnostic string surfaced to the UI. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    FString LastWarning;
+
+    /** Additional diagnostic string describing the zero-copy decision. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    FString ZeroCopyDiagnostic;
+
+    /** Effective video settings after preflight/fallback adjustments. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Status")
+    FPanoramicVideoSettings EffectiveVideoSettings;
+};
+
+/** Streaming audio packet produced by the submix recorder. */
+struct FPanoramaAudioPacket
+{
+    FPanoramaAudioPacket()
+        : TimestampSeconds(0.0)
+        , NumChannels(0)
+        , SampleRate(0)
+    {
+    }
+
+    /** Presentation timestamp anchored to the start of the capture session. */
+    double TimestampSeconds;
+
+    /** Number of interleaved channels in this packet. */
+    int32 NumChannels;
+
+    /** Sample rate in Hertz for the PCM payload. */
+    int32 SampleRate;
+
+    /** Interleaved little-endian PCM16 audio samples. */
+    TArray<uint8> PCMData;
+
+    /** Utility accessor that converts payload length into seconds. */
+    double GetDurationSeconds() const
+    {
+        const int32 BytesPerFrame = NumChannels * sizeof(int16);
+        if (BytesPerFrame <= 0 || SampleRate <= 0 || PCMData.Num() <= 0)
+        {
+            return 0.0;
+        }
+
+        const int32 FrameCount = PCMData.Num() / BytesPerFrame;
+        return static_cast<double>(FrameCount) / static_cast<double>(SampleRate);
+    }
+};
+
+DECLARE_DELEGATE(FPanoramaCaptureStarted);
+DECLARE_DELEGATE_OneParam(FPanoramaCaptureStopped, bool /*bSuccess*/);
+DECLARE_DELEGATE_OneParam(FPanoramaCaptureStatusUpdated, const FPanoramicCaptureStatus& /*Status*/);

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/PanoramaCaptureEditor.Build.cs
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/PanoramaCaptureEditor.Build.cs
@@ -1,0 +1,39 @@
+using UnrealBuildTool;
+using System.IO;
+
+public class PanoramaCaptureEditor : ModuleRules
+{
+    public PanoramaCaptureEditor(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "CoreUObject",
+                "Engine",
+                "Slate",
+                "SlateCore"
+            });
+
+        PrivateDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "PanoramaCapture",
+                "UnrealEd",
+                "LevelEditor",
+                "EditorSubsystem",
+                "ToolMenus"
+            });
+
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            PublicDefinitions.Add("PANORAMA_EDITOR_SUPPORTED=1");
+        }
+        else
+        {
+            PublicDefinitions.Add("PANORAMA_EDITOR_SUPPORTED=0");
+        }
+    }
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/PanoramaCaptureEditorModule.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/PanoramaCaptureEditorModule.cpp
@@ -1,0 +1,74 @@
+#include "PanoramaCaptureEditorModule.h"
+#include "SPanoramaCapturePanel.h"
+#include "PanoramaCaptureLog.h"
+#include "ToolMenus.h"
+#include "LevelEditor.h"
+#include "Modules/ModuleManager.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
+
+static const FName PanoramaCaptureTabName(TEXT("PanoramaCapturePanel"));
+
+void FPanoramaCaptureEditorModule::StartupModule()
+{
+    FGlobalTabmanager::Get()->RegisterNomadTabSpawner(PanoramaCaptureTabName, FOnSpawnTab::CreateRaw(this, &FPanoramaCaptureEditorModule::SpawnPanoramaTab))
+        .SetDisplayName(NSLOCTEXT("PanoramaCapture", "TabTitle", "Panorama Capture"))
+        .SetTooltipText(NSLOCTEXT("PanoramaCapture", "TabTooltip", "Panorama capture control panel"))
+        .SetGroup(WorkspaceMenu::GetMenuStructure().GetLevelEditorCategory());
+
+    if (UToolMenus::IsToolMenuUIEnabled())
+    {
+        MenuExtenderHandle = UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateRaw(this, &FPanoramaCaptureEditorModule::RegisterMenus));
+    }
+}
+
+void FPanoramaCaptureEditorModule::ShutdownModule()
+{
+    if (UToolMenus::Get())
+    {
+        UToolMenus::UnRegisterStartupCallback(MenuExtenderHandle);
+        UToolMenus::UnregisterOwner(this);
+    }
+
+    FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(PanoramaCaptureTabName);
+}
+
+TSharedRef<SDockTab> FPanoramaCaptureEditorModule::SpawnPanoramaTab(const FSpawnTabArgs& Args)
+{
+    return SNew(SDockTab)
+        .TabRole(ETabRole::NomadTab)
+        [
+            SNew(SPanoramaCapturePanel)
+        ];
+}
+
+void FPanoramaCaptureEditorModule::RegisterMenus()
+{
+    FToolMenuOwnerScoped OwnerScoped(this);
+    if (UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Window"))
+    {
+        FToolMenuSection& Section = Menu->FindOrAddSection("WindowLayout");
+        Section.AddMenuEntry(
+            TEXT("OpenPanoramaCapture"),
+            NSLOCTEXT("PanoramaCapture", "OpenPanel", "Panorama Capture"),
+            NSLOCTEXT("PanoramaCapture", "OpenPanelTooltip", "Open the panorama capture control panel."),
+            FSlateIcon(),
+            FUIAction(FExecuteAction::CreateLambda([]() { FGlobalTabmanager::Get()->TryInvokeTab(PanoramaCaptureTabName); }))
+        );
+    }
+
+    if (UToolMenu* ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar"))
+    {
+        FToolMenuSection& Section = ToolbarMenu->FindOrAddSection("Settings");
+        Section.AddEntry(FToolMenuEntry::InitToolBarButton(
+            TEXT("PanoramaCaptureToolbarButton"),
+            FUIAction(FExecuteAction::CreateLambda([]() { FGlobalTabmanager::Get()->TryInvokeTab(PanoramaCaptureTabName); })),
+            NSLOCTEXT("PanoramaCapture", "ToolbarButton", "Panorama"),
+            NSLOCTEXT("PanoramaCapture", "ToolbarButtonTooltip", "Open the panorama capture panel"),
+            FSlateIcon()
+        ));
+    }
+}
+
+IMPLEMENT_MODULE(FPanoramaCaptureEditorModule, PanoramaCaptureEditor)

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/PanoramaCaptureEditorModule.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/PanoramaCaptureEditorModule.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Modules/ModuleInterface.h"
+#include "ToolMenus.h"
+
+class SDockTab;
+struct FSpawnTabArgs;
+
+class FPanoramaCaptureEditorModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+
+private:
+    TSharedRef<SDockTab> SpawnPanoramaTab(const FSpawnTabArgs& Args);
+    void RegisterMenus();
+
+    FDelegateHandle MenuExtenderHandle;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/SPanoramaCapturePanel.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/SPanoramaCapturePanel.cpp
@@ -1,0 +1,980 @@
+#include "SPanoramaCapturePanel.h"
+#include "PanoramaCaptureComponent.h"
+#include "PanoramaCaptureTypes.h"
+#include "PanoramaCaptureLog.h"
+#include "Editor.h"
+#include "EngineUtils.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SComboBox.h"
+#include "Widgets/Input/SSpinBox.h"
+#include "Styling/AppStyle.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Notifications/SProgressBar.h"
+#include "Internationalization/Internationalization.h"
+
+void SPanoramaCapturePanel::Construct(const FArguments& InArgs)
+{
+    bRequestPreviewToggle = true;
+
+    OutputFormatOptions = {
+        MakeShared<EPanoramaOutputFormat>(EPanoramaOutputFormat::PNGSequence),
+        MakeShared<EPanoramaOutputFormat>(EPanoramaOutputFormat::NVENC)
+    };
+    CaptureModeOptions = {
+        MakeShared<EPanoramaCaptureMode>(EPanoramaCaptureMode::Mono),
+        MakeShared<EPanoramaCaptureMode>(EPanoramaCaptureMode::Stereo)
+    };
+    GammaOptions = {
+        MakeShared<EPanoramaGamma>(EPanoramaGamma::SRGB),
+        MakeShared<EPanoramaGamma>(EPanoramaGamma::Linear)
+    };
+    ColorFormatOptions = {
+        MakeShared<EPanoramaColorFormat>(EPanoramaColorFormat::NV12),
+        MakeShared<EPanoramaColorFormat>(EPanoramaColorFormat::P010),
+        MakeShared<EPanoramaColorFormat>(EPanoramaColorFormat::BGRA8)
+    };
+    StereoLayoutOptions = {
+        MakeShared<EPanoramaStereoLayout>(EPanoramaStereoLayout::TopBottom),
+        MakeShared<EPanoramaStereoLayout>(EPanoramaStereoLayout::SideBySide)
+    };
+    RateControlOptions = {
+        MakeShared<EPanoramaRateControlPreset>(EPanoramaRateControlPreset::Default),
+        MakeShared<EPanoramaRateControlPreset>(EPanoramaRateControlPreset::LowLatency),
+        MakeShared<EPanoramaRateControlPreset>(EPanoramaRateControlPreset::HighQuality)
+    };
+
+    RefreshComponentFromSelection();
+
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SAssignNew(ComponentCombo, SComboBox<TSharedPtr<FPanoramaComponentEntry>>)
+            .OptionsSource(&ComponentItems)
+            .OnGenerateWidget_Lambda([](TSharedPtr<FPanoramaComponentEntry> Item)
+            {
+                return SNew(STextBlock).Text(Item.IsValid() ? FText::FromString(Item->DisplayName) : FText::FromString(TEXT("None")));
+            })
+            .OnSelectionChanged_Lambda([this](TSharedPtr<FPanoramaComponentEntry> InItem, ESelectInfo::Type InType)
+            {
+                ActiveItem = InItem;
+                if (ActiveItem.IsValid())
+                {
+                    SelectedComponent = ActiveItem->Component.Get();
+                }
+            })
+            .InitiallySelectedItem(ActiveItem)
+            [
+                SNew(STextBlock)
+                .Text_Lambda([this]() -> FText
+                {
+                    if (ActiveItem.IsValid())
+                    {
+                        return FText::FromString(ActiveItem->DisplayName);
+                    }
+                    return FText::FromString(TEXT("Select Panorama Component"));
+                })
+            ]
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SSeparator)
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SButton)
+            .Text_Lambda([this]() { return GetStartStopButtonText(); })
+            .OnClicked(this, &SPanoramaCapturePanel::HandleStartStopButton)
+            .IsEnabled_Lambda([this]() { return SelectedComponent.IsValid(); })
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SCheckBox)
+            .OnCheckStateChanged(this, &SPanoramaCapturePanel::HandlePreviewToggled)
+            .IsChecked_Lambda([this]() { return GetPreviewCheckState(); })
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("Preview Enabled")))
+            ]
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(STextBlock)
+            .Text(FText::FromString(TEXT("Video Settings")))
+            .Font(FAppStyle::Get().GetFontStyle("HeadingExtraSmall"))
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("Output")))
+            ]
+            + SHorizontalBox::Slot()
+            .Padding(8.f, 0.f)
+            .AutoWidth()
+            [
+                SAssignNew(OutputFormatCombo, SComboBox<TSharedPtr<EPanoramaOutputFormat>>)
+                .OptionsSource(&OutputFormatOptions)
+                .OnGenerateWidget_Lambda([](TSharedPtr<EPanoramaOutputFormat> Item)
+                {
+                    const FString Label = Item.IsValid() && *Item == EPanoramaOutputFormat::NVENC ? TEXT("NVENC Hardware") : TEXT("PNG Sequence");
+                    return SNew(STextBlock).Text(FText::FromString(Label));
+                })
+                .OnSelectionChanged(this, &SPanoramaCapturePanel::HandleOutputFormatChanged)
+                .InitiallySelectedItem(SelectedOutputFormat)
+                [
+                    SNew(STextBlock)
+                    .Text_Lambda([this]() { return GetFormatSummaryText(); })
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(SCheckBox)
+                .OnCheckStateChanged(this, &SPanoramaCapturePanel::HandleHEVCToggled)
+                .IsChecked_Lambda([this]()
+                {
+                    return (SelectedComponent.IsValid() && SelectedComponent->VideoSettings.bUseHEVC) ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+                })
+                .IsEnabled_Lambda([this]() { return SelectedComponent.IsValid() && !SelectedComponent->IsCapturing(); })
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Use HEVC")))
+                ]
+            ]
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Mode")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SAssignNew(CaptureModeCombo, SComboBox<TSharedPtr<EPanoramaCaptureMode>>)
+                .OptionsSource(&CaptureModeOptions)
+                .OnGenerateWidget_Lambda([](TSharedPtr<EPanoramaCaptureMode> Item)
+                {
+                    const FString Label = (Item.IsValid() && *Item == EPanoramaCaptureMode::Stereo) ? TEXT("Stereo") : TEXT("Mono");
+                    return SNew(STextBlock).Text(FText::FromString(Label));
+                })
+                .OnSelectionChanged(this, &SPanoramaCapturePanel::HandleCaptureModeChanged)
+                .InitiallySelectedItem(SelectedCaptureMode)
+                [
+                    SNew(STextBlock).Text_Lambda([this]()
+                    {
+                        if (!SelectedComponent.IsValid())
+                        {
+                            return FText::FromString(TEXT("Mode"));
+                        }
+                        return SelectedComponent->VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo ? FText::FromString(TEXT("Stereo")) : FText::FromString(TEXT("Mono"));
+                    })
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Stereo Layout")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SAssignNew(StereoLayoutCombo, SComboBox<TSharedPtr<EPanoramaStereoLayout>>)
+                .OptionsSource(&StereoLayoutOptions)
+                .OnGenerateWidget_Lambda([](TSharedPtr<EPanoramaStereoLayout> Item)
+                {
+                    const FString Label = (Item.IsValid() && *Item == EPanoramaStereoLayout::SideBySide) ? TEXT("Side-by-Side") : TEXT("Top-Bottom");
+                    return SNew(STextBlock).Text(FText::FromString(Label));
+                })
+                .OnSelectionChanged(this, &SPanoramaCapturePanel::HandleStereoLayoutChanged)
+                .InitiallySelectedItem(SelectedStereoLayout)
+                .IsEnabled_Lambda([this]()
+                {
+                    return SelectedComponent.IsValid() && SelectedComponent->VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo && !SelectedComponent->IsCapturing();
+                })
+                [
+                    SNew(STextBlock).Text_Lambda([this]()
+                    {
+                        if (!SelectedComponent.IsValid())
+                        {
+                            return FText::FromString(TEXT("Layout"));
+                        }
+                        return (SelectedComponent->VideoSettings.StereoLayout == EPanoramaStereoLayout::SideBySide)
+                            ? FText::FromString(TEXT("Side-by-Side"))
+                            : FText::FromString(TEXT("Top-Bottom"));
+                    })
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Gamma")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SAssignNew(GammaCombo, SComboBox<TSharedPtr<EPanoramaGamma>>)
+                .OptionsSource(&GammaOptions)
+                .OnGenerateWidget_Lambda([](TSharedPtr<EPanoramaGamma> Item)
+                {
+                    const FString Label = (Item.IsValid() && *Item == EPanoramaGamma::Linear) ? TEXT("Linear") : TEXT("sRGB");
+                    return SNew(STextBlock).Text(FText::FromString(Label));
+                })
+                .OnSelectionChanged(this, &SPanoramaCapturePanel::HandleGammaChanged)
+                .InitiallySelectedItem(SelectedGamma)
+                [
+                    SNew(STextBlock).Text_Lambda([this]()
+                    {
+                        if (!SelectedComponent.IsValid())
+                        {
+                            return FText::FromString(TEXT("Gamma"));
+                        }
+                        return SelectedComponent->VideoSettings.Gamma == EPanoramaGamma::Linear ? FText::FromString(TEXT("Linear")) : FText::FromString(TEXT("sRGB"));
+                    })
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Color Format")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SAssignNew(ColorFormatCombo, SComboBox<TSharedPtr<EPanoramaColorFormat>>)
+                .OptionsSource(&ColorFormatOptions)
+                .OnGenerateWidget_Lambda([](TSharedPtr<EPanoramaColorFormat> Item)
+                {
+                    FString Label = TEXT("NV12 8-bit");
+                    if (Item.IsValid())
+                    {
+                        switch (*Item)
+                        {
+                        case EPanoramaColorFormat::NV12:
+                            Label = TEXT("NV12 8-bit");
+                            break;
+                        case EPanoramaColorFormat::P010:
+                            Label = TEXT("P010 10-bit");
+                            break;
+                        case EPanoramaColorFormat::BGRA8:
+                            Label = TEXT("BGRA 8-bit");
+                            break;
+                        default:
+                            break;
+                        }
+                    }
+                    return SNew(STextBlock).Text(FText::FromString(Label));
+                })
+                .OnSelectionChanged(this, &SPanoramaCapturePanel::HandleColorFormatChanged)
+                .InitiallySelectedItem(SelectedColorFormat)
+                .IsEnabled_Lambda([this]() { return SelectedComponent.IsValid() && !SelectedComponent->IsCapturing(); })
+                [
+                    SNew(STextBlock).Text_Lambda([this]()
+                    {
+                        return GetColorFormatSummaryText();
+                    })
+                ]
+            ]
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Bitrate (Mbps)")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SNew(SSpinBox<float>)
+                .MinValue(1.f)
+                .MaxValue(500.f)
+                .Delta(1.f)
+                .Value_Lambda([this]()
+                {
+                    return SelectedComponent.IsValid() ? static_cast<float>(SelectedComponent->VideoSettings.TargetBitrateMbps) : 0.f;
+                })
+                .OnValueCommitted(this, &SPanoramaCapturePanel::HandleBitrateCommitted)
+                .IsEnabled_Lambda([this]() { return SelectedComponent.IsValid() && !SelectedComponent->IsCapturing(); })
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("GOP")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SNew(SSpinBox<float>)
+                .MinValue(1.f)
+                .MaxValue(300.f)
+                .Delta(1.f)
+                .Value_Lambda([this]()
+                {
+                    return SelectedComponent.IsValid() ? static_cast<float>(SelectedComponent->VideoSettings.GOPLength) : 0.f;
+                })
+                .OnValueCommitted(this, &SPanoramaCapturePanel::HandleGOPCommitted)
+                .IsEnabled_Lambda([this]() { return SelectedComponent.IsValid() && !SelectedComponent->IsCapturing(); })
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("B-Frames")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SNew(SSpinBox<float>)
+                .MinValue(0.f)
+                .MaxValue(6.f)
+                .Delta(1.f)
+                .Value_Lambda([this]()
+                {
+                    return SelectedComponent.IsValid() ? static_cast<float>(SelectedComponent->VideoSettings.NumBFrames) : 0.f;
+                })
+                .OnValueCommitted(this, &SPanoramaCapturePanel::HandleBFramesCommitted)
+                .IsEnabled_Lambda([this]() { return SelectedComponent.IsValid() && !SelectedComponent->IsCapturing(); })
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(16.f, 0.f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Rate Control")))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(8.f, 0.f)
+            [
+                SAssignNew(RateControlCombo, SComboBox<TSharedPtr<EPanoramaRateControlPreset>>)
+                .OptionsSource(&RateControlOptions)
+                .OnGenerateWidget_Lambda([](TSharedPtr<EPanoramaRateControlPreset> Item)
+                {
+                    FString Label = TEXT("Default");
+                    if (Item.IsValid())
+                    {
+                        switch (*Item)
+                        {
+                        case EPanoramaRateControlPreset::LowLatency:
+                            Label = TEXT("Low Latency");
+                            break;
+                        case EPanoramaRateControlPreset::HighQuality:
+                            Label = TEXT("High Quality");
+                            break;
+                        default:
+                            Label = TEXT("Default");
+                            break;
+                        }
+                    }
+                    return SNew(STextBlock).Text(FText::FromString(Label));
+                })
+                .OnSelectionChanged(this, &SPanoramaCapturePanel::HandleRateControlChanged)
+                .InitiallySelectedItem(SelectedRateControl)
+                .IsEnabled_Lambda([this]()
+                {
+                    return SelectedComponent.IsValid() && SelectedComponent->VideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC && !SelectedComponent->IsCapturing();
+                })
+                [
+                    SNew(STextBlock).Text_Lambda([this]()
+                    {
+                        if (!SelectedComponent.IsValid())
+                        {
+                            return FText::FromString(TEXT("RC"));
+                        }
+                        switch (SelectedComponent->VideoSettings.RateControlPreset)
+                        {
+                        case EPanoramaRateControlPreset::LowLatency:
+                            return FText::FromString(TEXT("Low Latency"));
+                        case EPanoramaRateControlPreset::HighQuality:
+                            return FText::FromString(TEXT("High Quality"));
+                        default:
+                            return FText::FromString(TEXT("Default"));
+                        }
+                    })
+                ]
+            ]
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(STextBlock)
+            .Text_Lambda([this]() { return GetStatusText(); })
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(STextBlock)
+            .ColorAndOpacity(this, &SPanoramaCapturePanel::GetBufferWarningColor)
+            .Text_Lambda([this]() { return GetBufferStatusText(); })
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(SProgressBar)
+            .Percent_Lambda([this]() -> TOptional<float>
+            {
+                if (!SelectedComponent.IsValid())
+                {
+                    return 0.f;
+                }
+                return FMath::Clamp(SelectedComponent->GetCaptureStatus().RingBufferFill, 0.f, 1.f);
+            })
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(STextBlock)
+            .Text(this, &SPanoramaCapturePanel::GetPTSStatusText)
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(STextBlock)
+            .Text(this, &SPanoramaCapturePanel::GetNVENCStatusText)
+        ]
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        .Padding(4.f)
+        [
+            SNew(STextBlock)
+            .Text_Lambda([this]() { return GetWarningText(); })
+            .ColorAndOpacity(FSlateColor(FLinearColor(1.0f, 0.6f, 0.0f)))
+            .WrapTextAt(480.f)
+        ]
+    ];
+}
+
+void SPanoramaCapturePanel::Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime)
+{
+    RefreshComponentFromSelection();
+}
+
+FReply SPanoramaCapturePanel::HandleStartStopButton()
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FReply::Handled();
+    }
+
+    if (SelectedComponent->IsCapturing())
+    {
+        SelectedComponent->StopCapture();
+    }
+    else
+    {
+        SelectedComponent->StartCapture();
+    }
+
+    return FReply::Handled();
+}
+
+FText SPanoramaCapturePanel::GetStartStopButtonText() const
+{
+    if (SelectedComponent.IsValid() && SelectedComponent->IsCapturing())
+    {
+        return FText::FromString(TEXT("Stop Capture"));
+    }
+    return FText::FromString(TEXT("Start Capture"));
+}
+
+FText SPanoramaCapturePanel::GetStatusText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::FromString(TEXT("No component selected"));
+    }
+
+    const FPanoramicCaptureStatus Status = SelectedComponent->GetCaptureStatus();
+    FString Mode = SelectedComponent->VideoSettings.CaptureMode == EPanoramaCaptureMode::Stereo ? TEXT("Stereo") : TEXT("Mono");
+    if (Status.bUsingFallback)
+    {
+        Mode += TEXT(" (Fallback)");
+    }
+    FNumberFormattingOptions TimeFormat;
+    TimeFormat.SetMinimumFractionalDigits(1);
+    TimeFormat.SetMaximumFractionalDigits(1);
+
+    const FString StatusLabel = Status.bIsCapturing ? TEXT("Capturing") : TEXT("Idle");
+
+    return FText::Format(NSLOCTEXT("PanoramaCapture", "StatusText", "Status: {0} | Mode: {1} | Dropped: {2} | Time: {3} s"),
+        FText::FromString(StatusLabel),
+        FText::FromString(Mode),
+        FText::AsNumber(Status.DroppedFrames),
+        FText::AsNumber(Status.CurrentCaptureTimeSeconds, &TimeFormat));
+}
+
+FText SPanoramaCapturePanel::GetBufferStatusText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::GetEmpty();
+    }
+
+    const int32 Capacity = SelectedComponent->GetRingBufferCapacity();
+    const FPanoramicCaptureStatus Status = SelectedComponent->GetCaptureStatus();
+    const int32 Occupancy = Status.PendingFrameCount;
+    const float FillPercent = FMath::Clamp(Status.RingBufferFill * 100.0f, 0.0f, 100.0f);
+
+    FNumberFormattingOptions PercentFormat;
+    PercentFormat.SetMinimumFractionalDigits(0);
+    PercentFormat.SetMaximumFractionalDigits(0);
+
+    return FText::Format(NSLOCTEXT("PanoramaCapture", "BufferStatus", "Buffer: {0}/{1} ({2}% used)"),
+        FText::AsNumber(Occupancy),
+        FText::AsNumber(Capacity),
+        FText::AsNumber(FillPercent, &PercentFormat));
+}
+
+FText SPanoramaCapturePanel::GetPTSStatusText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::GetEmpty();
+    }
+
+    const FPanoramicCaptureStatus Status = SelectedComponent->GetCaptureStatus();
+    FNumberFormattingOptions Format;
+    Format.SetMinimumFractionalDigits(2);
+    Format.SetMaximumFractionalDigits(2);
+    const double Delta = FMath::Abs(Status.LastVideoPTS - Status.LastAudioPTS);
+
+    return FText::Format(NSLOCTEXT("PanoramaCapture", "PTSStatus", "Video PTS: {0}s | Audio PTS: {1}s | Δ: {2}s"),
+        FText::AsNumber(Status.LastVideoPTS, &Format),
+        FText::AsNumber(Status.LastAudioPTS, &Format),
+        FText::AsNumber(Delta, &Format));
+}
+
+FText SPanoramaCapturePanel::GetNVENCStatusText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::GetEmpty();
+    }
+
+    const FPanoramicCaptureStatus Status = SelectedComponent->GetCaptureStatus();
+    if (!Status.bUsingNVENC)
+    {
+        return NSLOCTEXT("PanoramaCapture", "NVENCStatusPNG", "Video Encoder: PNG Sequence");
+    }
+
+    const auto FormatToText = [](EPanoramaColorFormat Format)
+    {
+        switch (Format)
+        {
+        case EPanoramaColorFormat::NV12:
+            return NSLOCTEXT("PanoramaCapture", "ColorNV12", "NV12");
+        case EPanoramaColorFormat::P010:
+            return NSLOCTEXT("PanoramaCapture", "ColorP010", "P010");
+        case EPanoramaColorFormat::BGRA8:
+            return NSLOCTEXT("PanoramaCapture", "ColorBGRA8", "BGRA8");
+        default:
+            return NSLOCTEXT("PanoramaCapture", "ColorUnknown", "Unknown");
+        }
+    };
+
+    const FPanoramicVideoSettings& EffectiveSettings = Status.EffectiveVideoSettings;
+    const FText FormatText = FormatToText(EffectiveSettings.ColorFormat);
+    const FText PathText = Status.bZeroCopyRequested
+        ? (Status.bZeroCopyActive
+            ? NSLOCTEXT("PanoramaCapture", "ZeroCopyActive", "Zero-Copy")
+            : NSLOCTEXT("PanoramaCapture", "ZeroCopyFallback", "Copy Path"))
+        : NSLOCTEXT("PanoramaCapture", "ZeroCopyNotRequested", "Copy Path");
+
+    if (!Status.ZeroCopyDiagnostic.IsEmpty())
+    {
+        return FText::Format(NSLOCTEXT("PanoramaCapture", "NVENCStatusDetailed", "Video Encoder: NVENC ({0}, {1}) - {2}"),
+            FormatText,
+            PathText,
+            FText::FromString(Status.ZeroCopyDiagnostic));
+    }
+
+    return FText::Format(NSLOCTEXT("PanoramaCapture", "NVENCStatusBasic", "Video Encoder: NVENC ({0}, {1})"),
+        FormatText,
+        PathText);
+}
+
+FText SPanoramaCapturePanel::GetWarningText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::GetEmpty();
+    }
+
+    const FString& Warning = SelectedComponent->GetCaptureStatus().LastWarning;
+    return Warning.IsEmpty() ? FText::GetEmpty() : FText::FromString(Warning);
+}
+
+FSlateColor SPanoramaCapturePanel::GetBufferWarningColor() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FSlateColor::UseForeground();
+    }
+
+    const float Fill = SelectedComponent->GetCaptureStatus().RingBufferFill;
+    if (Fill >= 0.9f)
+    {
+        return FSlateColor(FLinearColor::Red);
+    }
+    if (Fill >= 0.7f)
+    {
+        return FSlateColor(FLinearColor::Yellow);
+    }
+    return FSlateColor::UseForeground();
+}
+
+ECheckBoxState SPanoramaCapturePanel::GetPreviewCheckState() const
+{
+    return bRequestPreviewToggle ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+FText SPanoramaCapturePanel::GetFormatSummaryText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::FromString(TEXT("Output"));
+    }
+
+    return SelectedComponent->VideoSettings.OutputFormat == EPanoramaOutputFormat::NVENC ? FText::FromString(TEXT("NVENC Hardware")) : FText::FromString(TEXT("PNG Sequence"));
+}
+
+FText SPanoramaCapturePanel::GetColorFormatSummaryText() const
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return FText::FromString(TEXT("Format"));
+    }
+
+    switch (SelectedComponent->VideoSettings.ColorFormat)
+    {
+    case EPanoramaColorFormat::NV12:
+        return FText::FromString(TEXT("NV12 8-bit"));
+    case EPanoramaColorFormat::P010:
+        return FText::FromString(TEXT("P010 10-bit"));
+    case EPanoramaColorFormat::BGRA8:
+        return FText::FromString(TEXT("BGRA 8-bit"));
+    default:
+        break;
+    }
+    return FText::FromString(TEXT("Format"));
+}
+
+void SPanoramaCapturePanel::RefreshComponentFromSelection()
+{
+    ComponentItems.Reset();
+    ActiveItem.Reset();
+
+#if WITH_EDITOR
+    if (GEditor)
+    {
+        if (UWorld* EditorWorld = GEditor->GetEditorWorldContext().World())
+        {
+            for (TActorIterator<AActor> It(EditorWorld); It; ++It)
+            {
+                if (UPanoramaCaptureComponent* Component = It->FindComponentByClass<UPanoramaCaptureComponent>())
+                {
+                    TSharedPtr<FPanoramaComponentEntry> Entry = MakeShared<FPanoramaComponentEntry>();
+                    Entry->Component = Component;
+                    Entry->DisplayName = It->GetActorLabel();
+                    ComponentItems.Add(Entry);
+                    if (Component == SelectedComponent.Get())
+                    {
+                        ActiveItem = Entry;
+                    }
+                }
+            }
+        }
+    }
+#endif
+
+    if (!ActiveItem.IsValid() && ComponentItems.Num() > 0)
+    {
+        ActiveItem = ComponentItems[0];
+        SelectedComponent = ActiveItem->Component.Get();
+    }
+
+    if (SelectedComponent.IsValid())
+    {
+        auto SelectOption = [](const auto& Options, auto Value)
+        {
+            for (const auto& Option : Options)
+            {
+                if (Option.IsValid() && *Option == Value)
+                {
+                    return Option;
+                }
+            }
+            return Options.Num() > 0 ? Options[0] : nullptr;
+        };
+
+        const FPanoramicCaptureStatus StatusSnapshot = SelectedComponent->GetCaptureStatus();
+        const FPanoramicVideoSettings& SourceSettings = (SelectedComponent->IsCapturing() || StatusSnapshot.bUsingFallback)
+            ? StatusSnapshot.EffectiveVideoSettings
+            : SelectedComponent->VideoSettings;
+
+        SelectedOutputFormat = SelectOption(OutputFormatOptions, SourceSettings.OutputFormat);
+        SelectedCaptureMode = SelectOption(CaptureModeOptions, SourceSettings.CaptureMode);
+        SelectedGamma = SelectOption(GammaOptions, SourceSettings.Gamma);
+        SelectedColorFormat = SelectOption(ColorFormatOptions, SourceSettings.ColorFormat);
+        SelectedStereoLayout = SelectOption(StereoLayoutOptions, SourceSettings.StereoLayout);
+        SelectedRateControl = SelectOption(RateControlOptions, SourceSettings.RateControlPreset);
+
+        if (OutputFormatCombo.IsValid())
+        {
+            OutputFormatCombo->SetSelectedItem(SelectedOutputFormat);
+        }
+        if (CaptureModeCombo.IsValid())
+        {
+            CaptureModeCombo->SetSelectedItem(SelectedCaptureMode);
+        }
+        if (GammaCombo.IsValid())
+        {
+            GammaCombo->SetSelectedItem(SelectedGamma);
+        }
+        if (ColorFormatCombo.IsValid())
+        {
+            ColorFormatCombo->SetSelectedItem(SelectedColorFormat);
+        }
+        if (StereoLayoutCombo.IsValid())
+        {
+            StereoLayoutCombo->SetSelectedItem(SelectedStereoLayout);
+        }
+        if (RateControlCombo.IsValid())
+        {
+            RateControlCombo->SetSelectedItem(SelectedRateControl);
+        }
+    }
+
+    if (ComponentCombo.IsValid())
+    {
+        ComponentCombo->RefreshOptions();
+        ComponentCombo->SetSelectedItem(ActiveItem);
+    }
+}
+
+void SPanoramaCapturePanel::ApplyVideoSettings(TFunctionRef<void(FPanoramicVideoSettings&)> Mutator)
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return;
+    }
+
+    FPanoramicVideoSettings Updated = SelectedComponent->VideoSettings;
+    Mutator(Updated);
+    SelectedComponent->VideoSettings = Updated;
+}
+
+void SPanoramaCapturePanel::ApplyAudioSettings(TFunctionRef<void(FPanoramicAudioSettings&)> Mutator)
+{
+    if (!SelectedComponent.IsValid())
+    {
+        return;
+    }
+
+    FPanoramicAudioSettings Updated = SelectedComponent->AudioSettings;
+    Mutator(Updated);
+    SelectedComponent->AudioSettings = Updated;
+}
+
+void SPanoramaCapturePanel::HandleHEVCToggled(ECheckBoxState NewState)
+{
+    if (!SelectedComponent.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    const bool bNewValue = (NewState == ECheckBoxState::Checked);
+    ApplyVideoSettings([bNewValue](FPanoramicVideoSettings& Settings)
+    {
+        Settings.bUseHEVC = bNewValue;
+    });
+}
+
+void SPanoramaCapturePanel::HandleOutputFormatChanged(TSharedPtr<EPanoramaOutputFormat> InFormat, ESelectInfo::Type)
+{
+    if (!SelectedComponent.IsValid() || !InFormat.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    SelectedOutputFormat = InFormat;
+    ApplyVideoSettings([InFormat](FPanoramicVideoSettings& Settings)
+    {
+        Settings.OutputFormat = *InFormat;
+    });
+}
+
+void SPanoramaCapturePanel::HandleCaptureModeChanged(TSharedPtr<EPanoramaCaptureMode> InMode, ESelectInfo::Type)
+{
+    if (!SelectedComponent.IsValid() || !InMode.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    SelectedCaptureMode = InMode;
+    ApplyVideoSettings([InMode](FPanoramicVideoSettings& Settings)
+    {
+        Settings.CaptureMode = *InMode;
+    });
+    SelectedComponent->ReinitializeRig();
+}
+
+void SPanoramaCapturePanel::HandleGammaChanged(TSharedPtr<EPanoramaGamma> InGamma, ESelectInfo::Type)
+{
+    if (!SelectedComponent.IsValid() || !InGamma.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    SelectedGamma = InGamma;
+    ApplyVideoSettings([InGamma](FPanoramicVideoSettings& Settings)
+    {
+        Settings.Gamma = *InGamma;
+    });
+}
+
+void SPanoramaCapturePanel::HandleColorFormatChanged(TSharedPtr<EPanoramaColorFormat> InFormat, ESelectInfo::Type)
+{
+    if (!SelectedComponent.IsValid() || !InFormat.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    SelectedColorFormat = InFormat;
+    ApplyVideoSettings([InFormat](FPanoramicVideoSettings& Settings)
+    {
+        Settings.ColorFormat = *InFormat;
+    });
+}
+
+void SPanoramaCapturePanel::HandleStereoLayoutChanged(TSharedPtr<EPanoramaStereoLayout> InLayout, ESelectInfo::Type)
+{
+    if (!SelectedComponent.IsValid() || !InLayout.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    SelectedStereoLayout = InLayout;
+    ApplyVideoSettings([InLayout](FPanoramicVideoSettings& Settings)
+    {
+        Settings.StereoLayout = *InLayout;
+    });
+}
+
+void SPanoramaCapturePanel::HandleRateControlChanged(TSharedPtr<EPanoramaRateControlPreset> InPreset, ESelectInfo::Type)
+{
+    if (!SelectedComponent.IsValid() || !InPreset.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    SelectedRateControl = InPreset;
+    ApplyVideoSettings([InPreset](FPanoramicVideoSettings& Settings)
+    {
+        Settings.RateControlPreset = *InPreset;
+    });
+}
+
+void SPanoramaCapturePanel::HandlePreviewToggled(ECheckBoxState NewState)
+{
+    bRequestPreviewToggle = (NewState == ECheckBoxState::Checked);
+    if (SelectedComponent.IsValid())
+    {
+        SelectedComponent->SetPreviewEnabled(bRequestPreviewToggle);
+    }
+}
+
+void SPanoramaCapturePanel::HandleBitrateCommitted(float NewValue, ETextCommit::Type CommitType)
+{
+    if (CommitType == ETextCommit::Default || !SelectedComponent.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    const int32 Rounded = FMath::Max(1, FMath::RoundToInt(NewValue));
+    ApplyVideoSettings([Rounded](FPanoramicVideoSettings& Settings)
+    {
+        Settings.TargetBitrateMbps = Rounded;
+    });
+}
+
+void SPanoramaCapturePanel::HandleGOPCommitted(float NewValue, ETextCommit::Type CommitType)
+{
+    if (CommitType == ETextCommit::Default || !SelectedComponent.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    const int32 Rounded = FMath::Clamp(FMath::RoundToInt(NewValue), 1, 300);
+    ApplyVideoSettings([Rounded](FPanoramicVideoSettings& Settings)
+    {
+        Settings.GOPLength = Rounded;
+    });
+}
+
+void SPanoramaCapturePanel::HandleBFramesCommitted(float NewValue, ETextCommit::Type CommitType)
+{
+    if (CommitType == ETextCommit::Default || !SelectedComponent.IsValid() || SelectedComponent->IsCapturing())
+    {
+        return;
+    }
+
+    const int32 Rounded = FMath::Clamp(FMath::RoundToInt(NewValue), 0, 6);
+    ApplyVideoSettings([Rounded](FPanoramicVideoSettings& Settings)
+    {
+        Settings.NumBFrames = Rounded;
+    });
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/SPanoramaCapturePanel.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/SPanoramaCapturePanel.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "PanoramaCaptureTypes.h"
+#include "Templates/Function.h"
+
+class UPanoramaCaptureComponent;
+template <typename OptionType> class SComboBox;
+
+struct FPanoramaComponentEntry
+{
+    TWeakObjectPtr<UPanoramaCaptureComponent> Component;
+    FString DisplayName;
+};
+
+class SPanoramaCapturePanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SPanoramaCapturePanel) {}
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+    virtual void Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
+
+private:
+    FReply HandleStartStopButton();
+
+    FText GetStartStopButtonText() const;
+    FText GetStatusText() const;
+    FText GetBufferStatusText() const;
+    FText GetPTSStatusText() const;
+    FText GetNVENCStatusText() const;
+    FSlateColor GetBufferWarningColor() const;
+    ECheckBoxState GetPreviewCheckState() const;
+    FText GetFormatSummaryText() const;
+    FText GetColorFormatSummaryText() const;
+
+    void RefreshComponentFromSelection();
+    void ApplyVideoSettings(TFunctionRef<void(FPanoramicVideoSettings&)> Mutator);
+    void ApplyAudioSettings(TFunctionRef<void(FPanoramicAudioSettings&)> Mutator);
+
+    void HandleHEVCToggled(ECheckBoxState NewState);
+    void HandleOutputFormatChanged(TSharedPtr<EPanoramaOutputFormat> InFormat, ESelectInfo::Type SelectInfo);
+    void HandleCaptureModeChanged(TSharedPtr<EPanoramaCaptureMode> InMode, ESelectInfo::Type SelectInfo);
+    void HandleGammaChanged(TSharedPtr<EPanoramaGamma> InGamma, ESelectInfo::Type SelectInfo);
+    void HandleColorFormatChanged(TSharedPtr<EPanoramaColorFormat> InFormat, ESelectInfo::Type SelectInfo);
+    void HandleStereoLayoutChanged(TSharedPtr<EPanoramaStereoLayout> InLayout, ESelectInfo::Type SelectInfo);
+    void HandleRateControlChanged(TSharedPtr<EPanoramaRateControlPreset> InPreset, ESelectInfo::Type SelectInfo);
+    void HandlePreviewToggled(ECheckBoxState NewState);
+    void HandleBitrateCommitted(float NewValue, ETextCommit::Type CommitType);
+    void HandleGOPCommitted(float NewValue, ETextCommit::Type CommitType);
+    void HandleBFramesCommitted(float NewValue, ETextCommit::Type CommitType);
+
+    FText GetWarningText() const;
+
+    TWeakObjectPtr<UPanoramaCaptureComponent> SelectedComponent;
+    bool bRequestPreviewToggle;
+    TArray<TSharedPtr<struct FPanoramaComponentEntry>> ComponentItems;
+    TSharedPtr<FPanoramaComponentEntry> ActiveItem;
+    TSharedPtr<SComboBox<TSharedPtr<FPanoramaComponentEntry>>> ComponentCombo;
+
+    TArray<TSharedPtr<EPanoramaOutputFormat>> OutputFormatOptions;
+    TSharedPtr<EPanoramaOutputFormat> SelectedOutputFormat;
+    TSharedPtr<SComboBox<TSharedPtr<EPanoramaOutputFormat>>> OutputFormatCombo;
+
+    TArray<TSharedPtr<EPanoramaCaptureMode>> CaptureModeOptions;
+    TSharedPtr<EPanoramaCaptureMode> SelectedCaptureMode;
+    TSharedPtr<SComboBox<TSharedPtr<EPanoramaCaptureMode>>> CaptureModeCombo;
+
+    TArray<TSharedPtr<EPanoramaGamma>> GammaOptions;
+    TSharedPtr<EPanoramaGamma> SelectedGamma;
+    TSharedPtr<SComboBox<TSharedPtr<EPanoramaGamma>>> GammaCombo;
+
+    TArray<TSharedPtr<EPanoramaColorFormat>> ColorFormatOptions;
+    TSharedPtr<EPanoramaColorFormat> SelectedColorFormat;
+    TSharedPtr<SComboBox<TSharedPtr<EPanoramaColorFormat>>> ColorFormatCombo;
+
+    TArray<TSharedPtr<EPanoramaStereoLayout>> StereoLayoutOptions;
+    TSharedPtr<EPanoramaStereoLayout> SelectedStereoLayout;
+    TSharedPtr<SComboBox<TSharedPtr<EPanoramaStereoLayout>>> StereoLayoutCombo;
+
+    TArray<TSharedPtr<EPanoramaRateControlPreset>> RateControlOptions;
+    TSharedPtr<EPanoramaRateControlPreset> SelectedRateControl;
+    TSharedPtr<SComboBox<TSharedPtr<EPanoramaRateControlPreset>>> RateControlCombo;
+};

--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# ggg
-v
+# Panorama Capture UE Plugin
+
+This repository contains a Windows-only Unreal Engine plugin that implements a full 360° capture workflow. The plugin targets UE 5.4–5.6 and provides:
+
+- Automatic six-camera rig generation for mono and stereo capture modes.
+- A render dependency graph (RDG) compute shader that stitches the cube captures into an equirectangular panorama.
+- Dual output pipelines covering 16-bit PNG sequences and NVENC hardware encoding with optional HEVC, selectable NV12/P010/BGRA color formats, stereo layout packing (top/bottom or side-by-side), and automatic gamma management.
+- NVENC zero-copy submission is currently limited to **BGRA8**. NV12 always relies on the CPU copy path, and P010 will only attempt zero-copy once the renderer grows dedicated 10-bit UAV support. These diagnostics surface in the editor panel so you can confirm which path is active at runtime.
+- Runtime diagnostics that negotiate the requested NVENC color format, report whether zero-copy is active, and fall back to CPU copy paths (with UI/log messaging) whenever the GPU or driver cannot satisfy BGRA8 or P010 requests.
+- AudioMixer submix recording, unified timestamps with drift compensation, and FFmpeg-based muxing into MP4/MKV containers with VR metadata (including projection and color primaries).
+- An in-editor control panel with codec controls (HEVC, bitrate, GOP, B-frames, rate-control presets), capture mode, gamma, color-format and stereo-layout selectors, live preview toggles, fallback warnings, and buffer health indicators.
+- Preflight diagnostics that validate NVENC availability, ffmpeg presence, and disk space before recording, automatically falling back to safe PNG output when needed.
+
+### NV12 / P010 零拷贝的实现条件
+
+目前的零拷贝只覆盖 BGRA8 纹理，要想让 NV12 或 P010 也走零拷贝，需要在渲染器和编码器之间完成更多 GPU 端准备工作：
+
+1. **GPU 平面纹理生成**：RDG Pass 需要额外输出 NV12/P010 所需的平面纹理（Y 与交错 UV，或 10-bit Y/UV），并保证纹理尺寸满足 NVENC 对齐规则。
+2. **RHI 资源兼容性**：这些平面纹理必须创建为 NVENC 可识别的 `ID3D11Texture2D`/`ID3D12Resource`，同时禁用自动 mip/tiling；否则注册时会失败。
+3. **NVENC 会话协商**：初始化时要把 `NV_ENC_BUFFER_FORMAT` 调整为 NV12 或 P010，启用 `enableOutputInVidmem`，并根据 `NvEncGetEncodeCaps` 查询 GPU 是否支持对应格式的 DirectX intake。
+4. **PNG / 预览共存**：PNG 序列和预览依赖线性 RGBA 数据，因此仍需保留当前的高精度缓冲，或者在编码后再转换，避免破坏无损输出。
+
+上述步骤尚未实装，因此 NV12/P010 依旧会回退到 CPU 转换路径。但只要补齐 GPU 平面写入和会话协商逻辑，这两种颜色格式理论上也可以纳入零拷贝管线。更详细的分阶段实施规划可参考 [`Docs/NV12_P010_ZeroCopyPlan.md`](Plugins/PanoramaCapture/Docs/NV12_P010_ZeroCopyPlan.md)。
+
+> **Note**: PNG sequence rendering, WAV capture via AudioMixer, and FFmpeg muxing are implemented but assume that `ffmpeg.exe` is present under `Plugins/PanoramaCapture/ThirdParty/Win64`. NVENC hardware encoding paths remain guarded by `PANORAMA_WITH_NVENC` and require NVIDIA's SDK libraries to be deployed.
+
+## Repository Layout
+
+```
+Plugins/
+  PanoramaCapture/
+    PanoramaCapture.uplugin
+    Shaders/
+      PanoramaEquirectCS.usf
+    Source/
+      PanoramaCapture/
+        Public/   – runtime API (component, manager, types, logging)
+        Private/  – render pipeline, audio capture, NVENC/FFmpeg bridges
+      PanoramaCaptureEditor/
+        Private/  – editor module and Slate control panel
+```
+
+## Building the Plugin
+
+1. Copy the `Plugins/PanoramaCapture` folder into your Unreal project.
+2. Regenerate project files (right-click `.uproject` → **Generate Visual Studio project files**).
+3. Build the project in Visual Studio 2022.
+4. Enable **Panorama Capture** in the project’s plugin settings (Windows only).
+
+## Using the Plugin
+
+1. Drag an actor with a `Panorama Capture Component` into the level.
+2. Configure video and audio settings in the details panel (resolution, bitrate, codec, gamma, capture mode).
+3. Use the **Panorama Capture** tab (Window → Panorama Capture) to start/stop recording, toggle previews, and monitor buffer usage.
+4. Recorded output (PNG/NVENC elementary streams and WAV) is written to `Saved/PanoramaCaptures` by default.
+
+The capture manager coordinates rendering, audio, encoding, and muxing, while the editor UI exposes live statistics and controls tailored for VR panoramic production workflows.


### PR DESCRIPTION
## Summary
- add compute shader coverage for NV12/P010 planar outputs so the render graph can feed NVENC without CPU conversion
- build NV12/P010 zero-copy textures in the renderer, copy them into combined NV12/P010 resources, and reuse them when populating frame metadata
- update NVENC negotiation and submission to request NV12/P010 formats, enable vidmem output, and reuse the shared zero-copy encode path

## Testing
- not run (Unreal Engine tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68d40ded2fcc8325ab601e5c4dfab66c